### PR TITLE
Refactor TypeVar usage

### DIFF
--- a/src/ffbb_api_client_v2/models/competition_id.py
+++ b/src/ffbb_api_client_v2/models/competition_id.py
@@ -1,7 +1,9 @@
 from typing import Any, Optional
 
 from .competition_id_categorie import CompetitionIDCategorie
-from .competition_id_type_competition_generique import CompetitionIDTypeCompetitionGenerique
+from .competition_id_type_competition_generique import (
+    CompetitionIDTypeCompetitionGenerique,
+)
 from .competition_origine import CompetitionOrigine
 from .converters import from_bool, from_none, from_str, from_union, to_class
 from .logo import Logo

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_competitions_request_args.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_competitions_request_args.py
@@ -1,4 +1,4 @@
-from typing import Any, Type, cast
+from typing import Any
 
 from .converters import from_int, to_class
 

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_competitions_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_competitions_response.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any, Callable, List, Optional, Type, cast
+from typing import Any, List, Optional
 from uuid import UUID
-
-import dateutil.parser
 
 from .converters import (
     from_bool,
@@ -19,7 +17,6 @@ from .converters import (
     to_enum,
     to_float,
 )
-
 
 
 class Categorie:

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_organismes_request_args.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_organismes_request_args.py
@@ -1,4 +1,4 @@
-from typing import Any, Type, cast
+from typing import Any
 
 from .converters import from_int, to_class
 

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_organismes_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_organismes_response.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any, Callable, List, Optional, Type, cast
+from typing import Any, List, Optional
 from uuid import UUID
-
-import dateutil.parser
 
 from .converters import (
     from_datetime,
@@ -17,7 +15,6 @@ from .converters import (
     to_enum,
     to_float,
 )
-
 
 
 class Cartographie:

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_poules_request_args.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_poules_request_args.py
@@ -1,4 +1,4 @@
-from typing import Any, Type, cast
+from typing import Any
 
 from .converters import from_int, to_class
 

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_poules_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_poules_response.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any, Callable, List, Optional, Type, cast
+from typing import Any, List, Optional
 from uuid import UUID
-
-import dateutil.parser
 
 from .converters import (
     from_bool,
@@ -19,7 +17,6 @@ from .converters import (
     to_enum,
     to_float,
 )
-
 
 
 class Nom(Enum):

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_saisons_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_saisons_response.py
@@ -1,7 +1,6 @@
-from typing import Any, Callable, List, Type, cast
+from typing import Any, List
 
 from .converters import from_list, from_str, to_class
-
 
 
 class Datum:

--- a/src/ffbb_api_client_v2/models/get_lives_json_response.py
+++ b/src/ffbb_api_client_v2/models/get_lives_json_response.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any, Callable, List, Optional, Type, cast
-
-import dateutil.parser
+from typing import Any, List, Optional
 
 from .converters import (
     from_datetime,
@@ -15,7 +13,6 @@ from .converters import (
     to_class,
     to_enum,
 )
-
 
 
 class CompetitionAbgName(Enum):

--- a/src/ffbb_api_client_v2/models/post_multi_search_request.py
+++ b/src/ffbb_api_client_v2/models/post_multi_search_request.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, List, Optional, Type, cast
+from typing import Any, List, Optional
 
 from .converters import (
     from_int,
@@ -8,7 +8,6 @@ from .converters import (
     from_union,
     to_class,
 )
-
 
 
 class Query:

--- a/src/ffbb_api_client_v2/models/post_multi_search_response.py
+++ b/src/ffbb_api_client_v2/models/post_multi_search_response.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Type, Union, cast
+from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
-
-import dateutil.parser
 
 from .converters import (
     from_bool,
@@ -21,7 +19,6 @@ from .converters import (
     to_enum,
     to_float,
 )
-
 
 
 class CompetitionIDSexeClass:


### PR DESCRIPTION
## Summary
- strip unused `TypeVar` declarations from generated model files
- centralize TypeVar definitions in `converters.py`

## Testing
- `pytest -q -c /dev/null` *(fails: ModuleNotFoundError for test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68416b678ddc832ba5292ec15877a1d2