### PR TITLE
Fix tox deps key

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ passenv =
 extras =
     testing
     python-dotenv
-desp =
+deps =
     pytest
 commands =
     pytest {posargs}


### PR DESCRIPTION
## Summary
- correct `deps` spelling in `tox.ini`

## Testing
- `tox -re default`

------
https://chatgpt.com/codex/tasks/task_e_684821428758832b8832c4e7dc998781