### PR TITLE
Refactor models to avoid duplication

### DIFF
--- a/src/ffbb_api_client_v2/models/get_ffbbserver_competitions_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_competitions_response.py
@@ -3,6 +3,13 @@ from enum import Enum
 from typing import Any, List, Optional
 from uuid import UUID
 
+from .cartographie import Cartographie
+from .commune import Commune
+from .categorie import Categorie
+from .id_organisme_equipe import IDOrganismeEquipe
+from .logo import Logo
+from .salle import Salle
+
 from ..utils.converters import (
     from_bool,
     from_datetime,
@@ -19,26 +26,6 @@ from ..utils.converters import (
 )
 
 
-class Categorie:
-    code: str
-    ordre: int
-
-    def __init__(self, code: str, ordre: int) -> None:
-        self.code = code
-        self.ordre = ordre
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Categorie":
-        assert isinstance(obj, dict)
-        code = from_str(obj.get("code"))
-        ordre = from_int(obj.get("ordre"))
-        return Categorie(code, ordre)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["code"] = from_str(self.code)
-        result["ordre"] = from_int(self.ordre)
-        return result
 
 
 class IDOrganisme:
@@ -127,24 +114,6 @@ class IDEngagementEquipe:
         return result
 
 
-class IDOrganismeEquipe:
-    logo: Optional[IDOrganisme]
-
-    def __init__(self, logo: Optional[IDOrganisme]) -> None:
-        self.logo = logo
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDOrganismeEquipe":
-        assert isinstance(obj, dict)
-        logo = from_union([IDOrganisme.from_dict, from_none], obj.get("logo"))
-        return IDOrganismeEquipe(logo)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["logo"] = from_union(
-            [lambda x: to_class(IDOrganisme, x), from_none], self.logo
-        )
-        return result
 
 
 class Libelle(Enum):
@@ -235,48 +204,6 @@ class AdresseComplement(Enum):
     MONTFAVET = "MONTFAVET"
 
 
-class Cartographie:
-    latitude: float
-    longitude: float
-
-    def __init__(self, latitude: float, longitude: float) -> None:
-        self.latitude = latitude
-        self.longitude = longitude
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Cartographie":
-        assert isinstance(obj, dict)
-        latitude = from_float(obj.get("latitude"))
-        longitude = from_float(obj.get("longitude"))
-        return Cartographie(latitude, longitude)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["latitude"] = to_float(self.latitude)
-        result["longitude"] = to_float(self.longitude)
-        return result
-
-
-class Commune:
-    code_postal: str
-    libelle: str
-
-    def __init__(self, code_postal: str, libelle: str) -> None:
-        self.code_postal = code_postal
-        self.libelle = libelle
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Commune":
-        assert isinstance(obj, dict)
-        code_postal = from_str(obj.get("codePostal"))
-        libelle = from_str(obj.get("libelle"))
-        return Commune(code_postal, libelle)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["codePostal"] = from_str(self.code_postal)
-        result["libelle"] = from_str(self.libelle)
-        return result
 
 
 class Libelle2(Enum):
@@ -288,71 +215,6 @@ class Libelle2(Enum):
     STADE_FOCH = "Stade foch"
 
 
-class Salle:
-    adresse: str
-    adresse_complement: AdresseComplement
-    cartographie: Cartographie
-    commune: Commune
-    id: str
-    libelle: str
-    libelle2: Libelle2
-    numero: int
-
-    def __init__(
-        self,
-        adresse: str,
-        adresse_complement: AdresseComplement,
-        cartographie: Cartographie,
-        commune: Commune,
-        id: str,
-        libelle: str,
-        libelle2: Libelle2,
-        numero: int,
-    ) -> None:
-        self.adresse = adresse
-        self.adresse_complement = adresse_complement
-        self.cartographie = cartographie
-        self.commune = commune
-        self.id = id
-        self.libelle = libelle
-        self.libelle2 = libelle2
-        self.numero = numero
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Salle":
-        assert isinstance(obj, dict)
-        adresse = from_str(obj.get("adresse"))
-        adresse_complement = AdresseComplement(obj.get("adresseComplement"))
-        cartographie = Cartographie.from_dict(obj.get("cartographie"))
-        commune = Commune.from_dict(obj.get("commune"))
-        id = from_str(obj.get("id"))
-        libelle = from_str(obj.get("libelle"))
-        libelle2 = Libelle2(obj.get("libelle2"))
-        numero = int(from_str(obj.get("numero")))
-        return Salle(
-            adresse,
-            adresse_complement,
-            cartographie,
-            commune,
-            id,
-            libelle,
-            libelle2,
-            numero,
-        )
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["adresse"] = from_str(self.adresse)
-        result["adresseComplement"] = to_enum(
-            AdresseComplement, self.adresse_complement
-        )
-        result["cartographie"] = to_class(Cartographie, self.cartographie)
-        result["commune"] = to_class(Commune, self.commune)
-        result["id"] = from_str(self.id)
-        result["libelle"] = from_str(self.libelle)
-        result["libelle2"] = to_enum(Libelle2, self.libelle2)
-        result["numero"] = from_str(str(self.numero))
-        return result
 
 
 class Rencontre:
@@ -619,26 +481,6 @@ class DataPoule:
         return result
 
 
-class Logo:
-    gradient_color: str
-    id: UUID
-
-    def __init__(self, gradient_color: str, id: UUID) -> None:
-        self.gradient_color = gradient_color
-        self.id = id
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Logo":
-        assert isinstance(obj, dict)
-        gradient_color = from_str(obj.get("gradient_color"))
-        id = UUID(obj.get("id"))
-        return Logo(gradient_color, id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["gradient_color"] = from_str(self.gradient_color)
-        result["id"] = str(self.id)
-        return result
 
 
 class TypeCompetitionGenerique:

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_competitions_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_competitions_response.py
@@ -1,19 +1,10 @@
 from datetime import datetime
 from enum import Enum
 from typing import Any, List, Optional
-from uuid import UUID
-
-from .cartographie import Cartographie
-from .commune import Commune
-from .categorie import Categorie
-from .id_organisme_equipe import IDOrganismeEquipe
-from .logo import Logo
-from .salle import Salle
 
 from ..utils.converters import (
     from_bool,
     from_datetime,
-    from_float,
     from_int,
     from_list,
     from_none,
@@ -22,10 +13,11 @@ from ..utils.converters import (
     is_type,
     to_class,
     to_enum,
-    to_float,
 )
-
-
+from .categorie import Categorie
+from .id_organisme_equipe import IDOrganismeEquipe
+from .logo import Logo
+from .salle import Salle
 
 
 class IDOrganisme:
@@ -112,8 +104,6 @@ class IDEngagementEquipe:
         result["nomOfficiel"] = from_union([from_none, from_str], self.nom_officiel)
         result["nomUsuel"] = from_union([from_none, from_str], self.nom_usuel)
         return result
-
-
 
 
 class Libelle(Enum):
@@ -204,8 +194,6 @@ class AdresseComplement(Enum):
     MONTFAVET = "MONTFAVET"
 
 
-
-
 class Libelle2(Enum):
     ANCIEN_GYMNASE_DE_LA_BARBIERE = "ancien GYMNASE DE LA BARBIERE"
     EMPTY = ""
@@ -213,8 +201,6 @@ class Libelle2(Enum):
     PARC_DES_SPORTS_POUDRERIE = "PARC DES SPORTS POUDRERIE"
     SALLE_NASARRE = "SALLE NASARRE"
     STADE_FOCH = "Stade foch"
-
-
 
 
 class Rencontre:
@@ -479,8 +465,6 @@ class DataPoule:
         result["id"] = from_str(self.id)
         result["nom"] = from_str(self.nom)
         return result
-
-
 
 
 class TypeCompetitionGenerique:

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_organismes_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_organismes_response.py
@@ -1,18 +1,9 @@
 from datetime import datetime
 from enum import Enum
 from typing import Any, List, Optional
-from uuid import UUID
-
-from .cartographie import Cartographie
-from .commune import Commune
-from .categorie import Categorie
-from .id_poule import IDPoule
-from .logo import Logo
-from .salle import Salle
 
 from ..utils.converters import (
     from_datetime,
-    from_float,
     from_int,
     from_list,
     from_none,
@@ -20,10 +11,13 @@ from ..utils.converters import (
     from_union,
     to_class,
     to_enum,
-    to_float,
 )
-
-
+from .cartographie import Cartographie
+from .categorie import Categorie
+from .commune import Commune
+from .id_poule import IDPoule
+from .logo import Logo
+from .salle import Salle
 
 
 class Code(Enum):
@@ -32,8 +26,6 @@ class Code(Enum):
     U13 = "U13"
     U15 = "U15"
     U17 = "U17"
-
-
 
 
 class IDCompetitionPere:
@@ -81,8 +73,6 @@ class Organisateur:
         return result
 
 
-
-
 class Sexe(Enum):
     F = "F"
     M = "M"
@@ -100,8 +90,6 @@ class GradientColor(Enum):
     ED3833 = "#ed3833"
     THE_00_B5_EA = "#00B5EA"
     THE_04378_B = "#04378B"
-
-
 
 
 class TypeCompetitionGenerique:
@@ -479,8 +467,6 @@ class OffresPratique:
             FfbbserverOffresPratiquesID, self.ffbbserver_offres_pratiques_id
         )
         return result
-
-
 
 
 class Data:

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_organismes_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_organismes_response.py
@@ -3,6 +3,13 @@ from enum import Enum
 from typing import Any, List, Optional
 from uuid import UUID
 
+from .cartographie import Cartographie
+from .commune import Commune
+from .categorie import Categorie
+from .id_poule import IDPoule
+from .logo import Logo
+from .salle import Salle
+
 from ..utils.converters import (
     from_datetime,
     from_float,
@@ -17,48 +24,6 @@ from ..utils.converters import (
 )
 
 
-class Cartographie:
-    latitude: float
-    longitude: float
-
-    def __init__(self, latitude: float, longitude: float) -> None:
-        self.latitude = latitude
-        self.longitude = longitude
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Cartographie":
-        assert isinstance(obj, dict)
-        latitude = from_float(obj.get("latitude"))
-        longitude = from_float(obj.get("longitude"))
-        return Cartographie(latitude, longitude)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["latitude"] = to_float(self.latitude)
-        result["longitude"] = to_float(self.longitude)
-        return result
-
-
-class Commune:
-    code_postal: int
-    libelle: str
-
-    def __init__(self, code_postal: int, libelle: str) -> None:
-        self.code_postal = code_postal
-        self.libelle = libelle
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Commune":
-        assert isinstance(obj, dict)
-        code_postal = int(from_str(obj.get("codePostal")))
-        libelle = from_str(obj.get("libelle"))
-        return Commune(code_postal, libelle)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["codePostal"] = from_str(str(self.code_postal))
-        result["libelle"] = from_str(self.libelle)
-        return result
 
 
 class Code(Enum):
@@ -69,26 +34,6 @@ class Code(Enum):
     U17 = "U17"
 
 
-class Categorie:
-    code: Code
-    ordre: int
-
-    def __init__(self, code: Code, ordre: int) -> None:
-        self.code = code
-        self.ordre = ordre
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Categorie":
-        assert isinstance(obj, dict)
-        code = Code(obj.get("code"))
-        ordre = from_int(obj.get("ordre"))
-        return Categorie(code, ordre)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["code"] = to_enum(Code, self.code)
-        result["ordre"] = from_int(self.ordre)
-        return result
 
 
 class IDCompetitionPere:
@@ -136,22 +81,6 @@ class Organisateur:
         return result
 
 
-class IDPoule:
-    id: str
-
-    def __init__(self, id: str) -> None:
-        self.id = id
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDPoule":
-        assert isinstance(obj, dict)
-        id = from_str(obj.get("id"))
-        return IDPoule(id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = from_str(self.id)
-        return result
 
 
 class Sexe(Enum):
@@ -173,26 +102,6 @@ class GradientColor(Enum):
     THE_04378_B = "#04378B"
 
 
-class Logo:
-    gradient_color: GradientColor
-    id: UUID
-
-    def __init__(self, gradient_color: GradientColor, id: UUID) -> None:
-        self.gradient_color = gradient_color
-        self.id = id
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Logo":
-        assert isinstance(obj, dict)
-        gradient_color = GradientColor(obj.get("gradient_color"))
-        id = UUID(obj.get("id"))
-        return Logo(gradient_color, id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["gradient_color"] = to_enum(GradientColor, self.gradient_color)
-        result["id"] = str(self.id)
-        return result
 
 
 class TypeCompetitionGenerique:
@@ -572,69 +481,6 @@ class OffresPratique:
         return result
 
 
-class Salle:
-    adresse: str
-    adresse_complement: str
-    cartographie: Cartographie
-    commune: Commune
-    id: str
-    libelle: str
-    libelle2: str
-    numero: int
-
-    def __init__(
-        self,
-        adresse: str,
-        adresse_complement: str,
-        cartographie: Cartographie,
-        commune: Commune,
-        id: str,
-        libelle: str,
-        libelle2: str,
-        numero: int,
-    ) -> None:
-        self.adresse = adresse
-        self.adresse_complement = adresse_complement
-        self.cartographie = cartographie
-        self.commune = commune
-        self.id = id
-        self.libelle = libelle
-        self.libelle2 = libelle2
-        self.numero = numero
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Salle":
-        assert isinstance(obj, dict)
-        adresse = from_str(obj.get("adresse"))
-        adresse_complement = from_str(obj.get("adresseComplement"))
-        cartographie = Cartographie.from_dict(obj.get("cartographie"))
-        commune = Commune.from_dict(obj.get("commune"))
-        id = from_str(obj.get("id"))
-        libelle = from_str(obj.get("libelle"))
-        libelle2 = from_str(obj.get("libelle2"))
-        numero = int(from_str(obj.get("numero")))
-        return Salle(
-            adresse,
-            adresse_complement,
-            cartographie,
-            commune,
-            id,
-            libelle,
-            libelle2,
-            numero,
-        )
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["adresse"] = from_str(self.adresse)
-        result["adresseComplement"] = from_str(self.adresse_complement)
-        result["cartographie"] = to_class(Cartographie, self.cartographie)
-        result["commune"] = to_class(Commune, self.commune)
-        result["id"] = from_str(self.id)
-        result["libelle"] = from_str(self.libelle)
-        result["libelle2"] = from_str(self.libelle2)
-        result["numero"] = from_str(str(self.numero))
-        return result
 
 
 class Data:

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_poules_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_poules_response.py
@@ -3,6 +3,12 @@ from enum import Enum
 from typing import Any, List, Optional
 from uuid import UUID
 
+from .cartographie import Cartographie
+from .commune import Commune
+from .id_organisme_equipe import IDOrganismeEquipe
+from .logo import Logo
+from .salle import Salle
+
 from ..utils.converters import (
     from_bool,
     from_datetime,
@@ -75,22 +81,6 @@ class IDEngagement:
         return result
 
 
-class Logo:
-    id: UUID
-
-    def __init__(self, id: UUID) -> None:
-        self.id = id
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Logo":
-        assert isinstance(obj, dict)
-        id = UUID(obj.get("id"))
-        return Logo(id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = str(self.id)
-        return result
 
 
 class Organisme:
@@ -258,22 +248,6 @@ class Classement:
         return result
 
 
-class IDOrganismeEquipe:
-    logo: Optional[Logo]
-
-    def __init__(self, logo: Optional[Logo]) -> None:
-        self.logo = logo
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDOrganismeEquipe":
-        assert isinstance(obj, dict)
-        logo = from_union([Logo.from_dict, from_none], obj.get("logo"))
-        return IDOrganismeEquipe(logo)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["logo"] = from_union([lambda x: to_class(Logo, x), from_none], self.logo)
-        return result
 
 
 class Libelle(Enum):
@@ -361,48 +335,6 @@ class AdresseComplement(Enum):
     MONTFAVET = "MONTFAVET"
 
 
-class Cartographie:
-    latitude: float
-    longitude: float
-
-    def __init__(self, latitude: float, longitude: float) -> None:
-        self.latitude = latitude
-        self.longitude = longitude
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Cartographie":
-        assert isinstance(obj, dict)
-        latitude = from_float(obj.get("latitude"))
-        longitude = from_float(obj.get("longitude"))
-        return Cartographie(latitude, longitude)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["latitude"] = to_float(self.latitude)
-        result["longitude"] = to_float(self.longitude)
-        return result
-
-
-class Commune:
-    code_postal: str
-    libelle: str
-
-    def __init__(self, code_postal: str, libelle: str) -> None:
-        self.code_postal = code_postal
-        self.libelle = libelle
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Commune":
-        assert isinstance(obj, dict)
-        code_postal = from_str(obj.get("codePostal"))
-        libelle = from_str(obj.get("libelle"))
-        return Commune(code_postal, libelle)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["codePostal"] = from_str(self.code_postal)
-        result["libelle"] = from_str(self.libelle)
-        return result
 
 
 class Libelle2(Enum):
@@ -411,71 +343,6 @@ class Libelle2(Enum):
     SALLE_NASARRE = "SALLE NASARRE"
 
 
-class Salle:
-    adresse: str
-    adresse_complement: AdresseComplement
-    cartographie: Cartographie
-    commune: Commune
-    id: str
-    libelle: str
-    libelle2: Libelle2
-    numero: int
-
-    def __init__(
-        self,
-        adresse: str,
-        adresse_complement: AdresseComplement,
-        cartographie: Cartographie,
-        commune: Commune,
-        id: str,
-        libelle: str,
-        libelle2: Libelle2,
-        numero: int,
-    ) -> None:
-        self.adresse = adresse
-        self.adresse_complement = adresse_complement
-        self.cartographie = cartographie
-        self.commune = commune
-        self.id = id
-        self.libelle = libelle
-        self.libelle2 = libelle2
-        self.numero = numero
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Salle":
-        assert isinstance(obj, dict)
-        adresse = from_str(obj.get("adresse"))
-        adresse_complement = AdresseComplement(obj.get("adresseComplement"))
-        cartographie = Cartographie.from_dict(obj.get("cartographie"))
-        commune = Commune.from_dict(obj.get("commune"))
-        id = from_str(obj.get("id"))
-        libelle = from_str(obj.get("libelle"))
-        libelle2 = Libelle2(obj.get("libelle2"))
-        numero = int(from_str(obj.get("numero")))
-        return Salle(
-            adresse,
-            adresse_complement,
-            cartographie,
-            commune,
-            id,
-            libelle,
-            libelle2,
-            numero,
-        )
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["adresse"] = from_str(self.adresse)
-        result["adresseComplement"] = to_enum(
-            AdresseComplement, self.adresse_complement
-        )
-        result["cartographie"] = to_class(Cartographie, self.cartographie)
-        result["commune"] = to_class(Commune, self.commune)
-        result["id"] = from_str(self.id)
-        result["libelle"] = from_str(self.libelle)
-        result["libelle2"] = to_enum(Libelle2, self.libelle2)
-        result["numero"] = from_str(str(self.numero))
-        return result
 
 
 class Rencontre:

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_poules_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_poules_response.py
@@ -1,13 +1,6 @@
 from datetime import datetime
 from enum import Enum
 from typing import Any, List, Optional
-from uuid import UUID
-
-from .cartographie import Cartographie
-from .commune import Commune
-from .id_organisme_equipe import IDOrganismeEquipe
-from .logo import Logo
-from .salle import Salle
 
 from ..utils.converters import (
     from_bool,
@@ -23,6 +16,9 @@ from ..utils.converters import (
     to_enum,
     to_float,
 )
+from .id_organisme_equipe import IDOrganismeEquipe
+from .logo import Logo
+from .salle import Salle
 
 
 class Nom(Enum):
@@ -79,8 +75,6 @@ class IDEngagement:
             result["nomOfficiel"] = from_union([from_none, from_str], self.nom_officiel)
         result["nomUsuel"] = from_union([from_none, from_str], self.nom_usuel)
         return result
-
-
 
 
 class Organisme:
@@ -248,8 +242,6 @@ class Classement:
         return result
 
 
-
-
 class Libelle(Enum):
     AIDE_MARQUEUR = "Aide marqueur"
     ARBITRE = "Arbitre"
@@ -335,14 +327,10 @@ class AdresseComplement(Enum):
     MONTFAVET = "MONTFAVET"
 
 
-
-
 class Libelle2(Enum):
     EMPTY = ""
     PARC_DES_SPORTS_POUDRERIE = "PARC DES SPORTS POUDRERIE"
     SALLE_NASARRE = "SALLE NASARRE"
-
-
 
 
 class Rencontre:

--- a/src/ffbb_api_client_v2/models/get_lives_json_response.py
+++ b/src/ffbb_api_client_v2/models/get_lives_json_response.py
@@ -14,6 +14,9 @@ from ..utils.converters import (
     to_enum,
 )
 from .competition_id import CompetitionID
+from .id_organisme_equipe import IDOrganismeEquipe
+from .id_poule import IDPoule
+from .salle import Salle
 
 
 class CompetitionAbgName(Enum):
@@ -50,28 +53,6 @@ class IDEngagementEquipe1:
         return result
 
 
-class IDOrganismeEquipe:
-    id: str
-    logo: Optional[IDEngagementEquipe1]
-
-    def __init__(self, id: str, logo: Optional[IDEngagementEquipe1]) -> None:
-        self.id = id
-        self.logo = logo
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDOrganismeEquipe":
-        assert isinstance(obj, dict)
-        id = from_str(obj.get("id"))
-        logo = from_union([IDEngagementEquipe1.from_dict, from_none], obj.get("logo"))
-        return IDOrganismeEquipe(id, logo)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = from_str(self.id)
-        result["logo"] = from_union(
-            [lambda x: to_class(IDEngagementEquipe1, x), from_none], self.logo
-        )
-        return result
 
 
 class Nom(Enum):
@@ -80,48 +61,8 @@ class Nom(Enum):
     POULE_A = "Poule A"
 
 
-class IDPoule:
-    id: str
-    nom: Nom
-
-    def __init__(self, id: str, nom: Nom) -> None:
-        self.id = id
-        self.nom = nom
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDPoule":
-        assert isinstance(obj, dict)
-        id = from_str(obj.get("id"))
-        nom = Nom(obj.get("nom"))
-        return IDPoule(id, nom)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = from_str(self.id)
-        result["nom"] = to_enum(Nom, self.nom)
-        return result
 
 
-class Salle:
-    libelle: str
-    libelle2: str
-
-    def __init__(self, libelle: str, libelle2: str) -> None:
-        self.libelle = libelle
-        self.libelle2 = libelle2
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Salle":
-        assert isinstance(obj, dict)
-        libelle = from_str(obj.get("libelle"))
-        libelle2 = from_str(obj.get("libelle2"))
-        return Salle(libelle, libelle2)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["libelle"] = from_str(self.libelle)
-        result["libelle2"] = from_str(self.libelle2)
-        return result
 
 
 class ExternalID:

--- a/src/ffbb_api_client_v2/models/get_lives_json_response.py
+++ b/src/ffbb_api_client_v2/models/get_lives_json_response.py
@@ -53,16 +53,10 @@ class IDEngagementEquipe1:
         return result
 
 
-
-
 class Nom(Enum):
     GROUPE_A = "Groupe A"
     GROUPE_B = "Groupe B"
     POULE_A = "Poule A"
-
-
-
-
 
 
 class ExternalID:

--- a/src/ffbb_api_client_v2/models/multi_search_result_pratiques.py
+++ b/src/ffbb_api_client_v2/models/multi_search_result_pratiques.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
+
+from .cartographie import Cartographie
 from uuid import UUID
 
 from ..utils.converters import (
@@ -214,104 +216,6 @@ class Status(Enum):
     DRAFT = "draft"
 
 
-class Cartographie:
-    adresse: Optional[str] = None
-    code_postal: Optional[str] = None
-    coordonnees: Optional[Coordonnees] = None
-    date_created: None
-    date_updated: None
-    id: Optional[str] = None
-    latitude: Optional[float] = None
-    longitude: Optional[float] = None
-    title: Optional[str] = None
-    ville: Optional[str] = None
-    status: Optional[Status] = None
-
-    def __init__(
-        self,
-        adresse: Optional[str],
-        code_postal: Optional[str],
-        coordonnees: Optional[Coordonnees],
-        date_created: None,
-        date_updated: None,
-        id: Optional[str],
-        latitude: Optional[float],
-        longitude: Optional[float],
-        title: Optional[str],
-        ville: Optional[str],
-        status: Optional[Status] = None,
-    ) -> None:
-        self.adresse = adresse
-        self.code_postal = code_postal
-        self.coordonnees = coordonnees
-        self.date_created = date_created
-        self.date_updated = date_updated
-        self.id = id
-        self.latitude = latitude
-        self.longitude = longitude
-        self.title = title
-        self.ville = ville
-        self.status = status
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Cartographie":
-        assert isinstance(obj, dict)
-        adresse = from_union([from_str, from_none], obj.get("adresse"))
-        code_postal = from_union([from_str, from_none], obj.get("codePostal"))
-        coordonnees = from_union(
-            [Coordonnees.from_dict, from_none], obj.get("coordonnees")
-        )
-        date_created = from_none(obj.get("date_created"))
-        date_updated = from_none(obj.get("date_updated"))
-        id = from_union([from_str, from_none], obj.get("id"))
-        latitude = from_union([from_float, from_none], obj.get("latitude"))
-        longitude = from_union([from_float, from_none], obj.get("longitude"))
-        title = from_union([from_str, from_none], obj.get("title"))
-        ville = from_union([from_str, from_none], obj.get("ville"))
-        status = from_union([Status, from_none], obj.get("status"))
-        return Cartographie(
-            adresse,
-            code_postal,
-            coordonnees,
-            date_created,
-            date_updated,
-            id,
-            latitude,
-            longitude,
-            title,
-            ville,
-            status,
-        )
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.adresse is not None:
-            result["adresse"] = from_union([from_str, from_none], self.adresse)
-        if self.code_postal is not None:
-            result["codePostal"] = from_union([from_str, from_none], self.code_postal)
-        if self.coordonnees is not None:
-            result["coordonnees"] = from_union(
-                [lambda x: to_class(Coordonnees, x), from_none], self.coordonnees
-            )
-        if self.date_created is not None:
-            result["date_created"] = from_none(self.date_created)
-        if self.date_updated is not None:
-            result["date_updated"] = from_none(self.date_updated)
-        if self.id is not None:
-            result["id"] = from_union([from_str, from_none], self.id)
-        if self.latitude is not None:
-            result["latitude"] = from_union([to_float, from_none], self.latitude)
-        if self.longitude is not None:
-            result["longitude"] = from_union([to_float, from_none], self.longitude)
-        if self.title is not None:
-            result["title"] = from_union([from_str, from_none], self.title)
-        if self.ville is not None:
-            result["ville"] = from_union([from_str, from_none], self.ville)
-        if self.status is not None:
-            result["status"] = from_union(
-                [lambda x: to_enum(Status, x), from_none], self.status
-            )
-        return result
 
 
 class Geo:

--- a/src/ffbb_api_client_v2/models/multi_search_result_pratiques.py
+++ b/src/ffbb_api_client_v2/models/multi_search_result_pratiques.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
-
-from .cartographie import Cartographie
 from uuid import UUID
 
 from ..utils.converters import (
@@ -19,6 +17,7 @@ from ..utils.converters import (
     to_enum,
     to_float,
 )
+from .cartographie import Cartographie
 from .facet_distribution import FacetDistribution
 from .facet_stats import FacetStats
 from .hit import Hit
@@ -214,8 +213,6 @@ class Coordonnees:
 
 class Status(Enum):
     DRAFT = "draft"
-
-
 
 
 class Geo:

--- a/src/ffbb_api_client_v2/models/post_multi_search_response.py
+++ b/src/ffbb_api_client_v2/models/post_multi_search_response.py
@@ -3,6 +3,13 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
+from .cartographie import Cartographie
+from .commune import Commune
+from .id_organisme_equipe import IDOrganismeEquipe
+from .id_poule import IDPoule
+from .logo import Logo
+from .salle import Salle
+
 from ..utils.converters import (
     from_bool,
     from_datetime,
@@ -554,87 +561,6 @@ class CartographieStatus(Enum):
     DRAFT = "draft"
 
 
-class Cartographie:
-    adresse: Optional[str]
-    code_postal: str
-    coordonnees: Coordonnees
-    date_created: None
-    date_updated: None
-    id: str
-    latitude: float
-    longitude: float
-    status: CartographieStatus
-    title: Optional[str]
-    ville: str
-
-    def __init__(
-        self,
-        adresse: Optional[str],
-        code_postal: str,
-        coordonnees: Coordonnees,
-        date_created: None,
-        date_updated: None,
-        id: str,
-        latitude: float,
-        longitude: float,
-        status: CartographieStatus,
-        title: Optional[str],
-        ville: str,
-    ) -> None:
-        self.adresse = adresse
-        self.code_postal = code_postal
-        self.coordonnees = coordonnees
-        self.date_created = date_created
-        self.date_updated = date_updated
-        self.id = id
-        self.latitude = latitude
-        self.longitude = longitude
-        self.status = status
-        self.title = title
-        self.ville = ville
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Cartographie":
-        assert isinstance(obj, dict)
-        adresse = from_union([from_none, from_str], obj.get("adresse"))
-        code_postal = from_str(obj.get("codePostal"))
-        coordonnees = Coordonnees.from_dict(obj.get("coordonnees"))
-        date_created = from_none(obj.get("date_created"))
-        date_updated = from_none(obj.get("date_updated"))
-        id = from_str(obj.get("id"))
-        latitude = from_float(obj.get("latitude"))
-        longitude = from_float(obj.get("longitude"))
-        status = CartographieStatus(obj.get("status"))
-        title = from_union([from_none, from_str], obj.get("title"))
-        ville = from_str(obj.get("ville"))
-        return Cartographie(
-            adresse,
-            code_postal,
-            coordonnees,
-            date_created,
-            date_updated,
-            id,
-            latitude,
-            longitude,
-            status,
-            title,
-            ville,
-        )
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["adresse"] = from_union([from_none, from_str], self.adresse)
-        result["codePostal"] = from_str(self.code_postal)
-        result["coordonnees"] = to_class(Coordonnees, self.coordonnees)
-        result["date_created"] = from_none(self.date_created)
-        result["date_updated"] = from_none(self.date_updated)
-        result["id"] = from_str(self.id)
-        result["latitude"] = to_float(self.latitude)
-        result["longitude"] = to_float(self.longitude)
-        result["status"] = to_enum(CartographieStatus, self.status)
-        result["title"] = from_union([from_none, from_str], self.title)
-        result["ville"] = from_str(self.ville)
-        return result
 
 
 class CategorieCode(Enum):
@@ -879,71 +805,6 @@ class Departement(Enum):
     YVELINES = "Yvelines"
 
 
-class Commune:
-    code_insee: None
-    code_postal: str
-    date_created: Optional[datetime]
-    date_updated: Optional[datetime]
-    departement: Departement
-    id: Optional[str]
-    libelle: str
-
-    def __init__(
-        self,
-        code_insee: None,
-        code_postal: str,
-        date_created: Optional[datetime],
-        date_updated: Optional[datetime],
-        departement: Departement,
-        id: Optional[str],
-        libelle: str,
-    ) -> None:
-        self.code_insee = code_insee
-        self.code_postal = code_postal
-        self.date_created = date_created
-        self.date_updated = date_updated
-        self.departement = departement
-        self.id = id
-        self.libelle = libelle
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Commune":
-        assert isinstance(obj, dict)
-        code_insee = from_none(obj.get("codeInsee"))
-        code_postal = from_str(obj.get("codePostal"))
-        date_created = from_union([from_datetime, from_none], obj.get("date_created"))
-        date_updated = from_union([from_datetime, from_none], obj.get("date_updated"))
-        departement = Departement(obj.get("departement"))
-        id = from_union([from_str, from_none], obj.get("id"))
-        libelle = from_str(obj.get("libelle"))
-        return Commune(
-            code_insee,
-            code_postal,
-            date_created,
-            date_updated,
-            departement,
-            id,
-            libelle,
-        )
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.code_insee is not None:
-            result["codeInsee"] = from_none(self.code_insee)
-        result["codePostal"] = from_str(self.code_postal)
-        if self.date_created is not None:
-            result["date_created"] = from_union(
-                [lambda x: x.isoformat(), from_none], self.date_created
-            )
-        if self.date_updated is not None:
-            result["date_updated"] = from_union(
-                [lambda x: x.isoformat(), from_none], self.date_updated
-            )
-        result["departement"] = to_enum(Departement, self.departement)
-        if self.id is not None:
-            result["id"] = from_union([from_str, from_none], self.id)
-        result["libelle"] = from_str(self.libelle)
-        return result
 
 
 class CommuneClubPro:
@@ -1147,26 +1008,6 @@ class CompetitionIDTypeCompetitionEnum(Enum):
     PLATEAU = "Plateau"
 
 
-class Logo:
-    gradient_color: str
-    id: UUID
-
-    def __init__(self, gradient_color: str, id: UUID) -> None:
-        self.gradient_color = gradient_color
-        self.id = id
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Logo":
-        assert isinstance(obj, dict)
-        gradient_color = from_str(obj.get("gradient_color"))
-        id = UUID(obj.get("id"))
-        return Logo(gradient_color, id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["gradient_color"] = from_str(self.gradient_color)
-        result["id"] = str(self.id)
-        return result
 
 
 class CompetitionIDTypeCompetitionGenerique:
@@ -1773,74 +1614,6 @@ class NomClubPro(Enum):
     VANVES_GPSO_BASKET = "VANVES GPSO BASKET"
 
 
-class IDOrganismeEquipe:
-    code: str
-    id: str
-    logo: Optional[Logo]
-    nom: str
-    nom_simple: None
-    nom_club_pro: Optional[NomClubPro]
-
-    def __init__(
-        self,
-        code: str,
-        id: str,
-        logo: Optional[Logo],
-        nom: str,
-        nom_simple: None,
-        nom_club_pro: Optional[NomClubPro],
-    ) -> None:
-        self.code = code
-        self.id = id
-        self.logo = logo
-        self.nom = nom
-        self.nom_simple = nom_simple
-        self.nom_club_pro = nom_club_pro
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDOrganismeEquipe":
-        assert isinstance(obj, dict)
-        code = from_str(obj.get("code"))
-        id = from_str(obj.get("id"))
-        logo = from_union([Logo.from_dict, from_none], obj.get("logo"))
-        nom = from_str(obj.get("nom"))
-        nom_simple = from_none(obj.get("nom_simple"))
-        nom_club_pro = from_union([from_none, NomClubPro], obj.get("nomClubPro"))
-        return IDOrganismeEquipe(code, id, logo, nom, nom_simple, nom_club_pro)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["code"] = from_str(self.code)
-        result["id"] = from_str(self.id)
-        result["logo"] = from_union([lambda x: to_class(Logo, x), from_none], self.logo)
-        result["nom"] = from_str(self.nom)
-        result["nom_simple"] = from_none(self.nom_simple)
-        result["nomClubPro"] = from_union(
-            [from_none, lambda x: to_enum(NomClubPro, x)], self.nom_club_pro
-        )
-        return result
-
-
-class IDPoule:
-    id: str
-    nom: str
-
-    def __init__(self, id: str, nom: str) -> None:
-        self.id = id
-        self.nom = nom
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDPoule":
-        assert isinstance(obj, dict)
-        id = from_str(obj.get("id"))
-        nom = from_str(obj.get("nom"))
-        return IDPoule(id, nom)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = from_str(self.id)
-        result["nom"] = from_str(self.nom)
-        return result
 
 
 class Jour(Enum):
@@ -2490,53 +2263,6 @@ class Saison:
         return result
 
 
-class Salle:
-    adresse: Optional[str]
-    adresse_complement: Optional[str]
-    cartographie: Optional[Cartographie]
-    id: str
-    libelle: str
-
-    def __init__(
-        self,
-        adresse: Optional[str],
-        adresse_complement: Optional[str],
-        cartographie: Optional[Cartographie],
-        id: str,
-        libelle: str,
-    ) -> None:
-        self.adresse = adresse
-        self.adresse_complement = adresse_complement
-        self.cartographie = cartographie
-        self.id = id
-        self.libelle = libelle
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Salle":
-        assert isinstance(obj, dict)
-        adresse = from_union([from_none, from_str], obj.get("adresse"))
-        adresse_complement = from_union(
-            [from_none, from_str], obj.get("adresseComplement")
-        )
-        cartographie = from_union(
-            [Cartographie.from_dict, from_none], obj.get("cartographie")
-        )
-        id = from_str(obj.get("id"))
-        libelle = from_str(obj.get("libelle"))
-        return Salle(adresse, adresse_complement, cartographie, id, libelle)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["adresse"] = from_union([from_none, from_str], self.adresse)
-        result["adresseComplement"] = from_union(
-            [from_none, from_str], self.adresse_complement
-        )
-        result["cartographie"] = from_union(
-            [lambda x: to_class(Cartographie, x), from_none], self.cartographie
-        )
-        result["id"] = from_str(self.id)
-        result["libelle"] = from_str(self.libelle)
-        return result
 
 
 class HitStatus(Enum):

--- a/src/ffbb_api_client_v2/models/post_multi_search_response.py
+++ b/src/ffbb_api_client_v2/models/post_multi_search_response.py
@@ -3,13 +3,6 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
-from .cartographie import Cartographie
-from .commune import Commune
-from .id_organisme_equipe import IDOrganismeEquipe
-from .id_poule import IDPoule
-from .logo import Logo
-from .salle import Salle
-
 from ..utils.converters import (
     from_bool,
     from_datetime,
@@ -26,6 +19,12 @@ from ..utils.converters import (
     to_enum,
     to_float,
 )
+from .cartographie import Cartographie
+from .commune import Commune
+from .id_organisme_equipe import IDOrganismeEquipe
+from .id_poule import IDPoule
+from .logo import Logo
+from .salle import Salle
 
 
 class CompetitionIDSexe:
@@ -561,8 +560,6 @@ class CartographieStatus(Enum):
     DRAFT = "draft"
 
 
-
-
 class CategorieCode(Enum):
     BIT = "BIT"
     BT = "BT"
@@ -805,8 +802,6 @@ class Departement(Enum):
     YVELINES = "Yvelines"
 
 
-
-
 class CommuneClubPro:
     code_postal: str
     departement: Departement
@@ -1006,8 +1001,6 @@ class CompetitionIDTypeCompetitionEnum(Enum):
     CHAMPIONNAT_3_X3 = "Championnat 3x3"
     COUPE = "Coupe"
     PLATEAU = "Plateau"
-
-
 
 
 class CompetitionIDTypeCompetitionGenerique:
@@ -1612,8 +1605,6 @@ class NomClubPro(Enum):
     TOURS_METROPOLE_BASKET = "TOURS METROPOLE BASKET"
     UJAP_QUIMPER_29 = "UJAP QUIMPER 29"
     VANVES_GPSO_BASKET = "VANVES GPSO BASKET"
-
-
 
 
 class Jour(Enum):
@@ -2261,8 +2252,6 @@ class Saison:
         result: dict = {}
         result["code"] = to_enum(SaisonCode, self.code)
         return result
-
-
 
 
 class HitStatus(Enum):


### PR DESCRIPTION
## Summary
- remove inline model definitions
- import shared models from their dedicated modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError & missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_684857f6f684832bad13f3c691c7e5a9