### PR TITLE
Remove duplicate ID classes

### DIFF
--- a/src/ffbb_api_client_v2/models/get_ffbbserver_competitions_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_competitions_response.py
@@ -17,6 +17,8 @@ from ..utils.converters import (
     to_enum,
     to_float,
 )
+from .id_organisme_equipe import IDOrganismeEquipe
+from .salle import Salle
 
 
 class Categorie:
@@ -127,24 +129,6 @@ class IDEngagementEquipe:
         return result
 
 
-class IDOrganismeEquipe:
-    logo: Optional[IDOrganisme]
-
-    def __init__(self, logo: Optional[IDOrganisme]) -> None:
-        self.logo = logo
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDOrganismeEquipe":
-        assert isinstance(obj, dict)
-        logo = from_union([IDOrganisme.from_dict, from_none], obj.get("logo"))
-        return IDOrganismeEquipe(logo)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["logo"] = from_union(
-            [lambda x: to_class(IDOrganisme, x), from_none], self.logo
-        )
-        return result
 
 
 class Libelle(Enum):
@@ -288,71 +272,6 @@ class Libelle2(Enum):
     STADE_FOCH = "Stade foch"
 
 
-class Salle:
-    adresse: str
-    adresse_complement: AdresseComplement
-    cartographie: Cartographie
-    commune: Commune
-    id: str
-    libelle: str
-    libelle2: Libelle2
-    numero: int
-
-    def __init__(
-        self,
-        adresse: str,
-        adresse_complement: AdresseComplement,
-        cartographie: Cartographie,
-        commune: Commune,
-        id: str,
-        libelle: str,
-        libelle2: Libelle2,
-        numero: int,
-    ) -> None:
-        self.adresse = adresse
-        self.adresse_complement = adresse_complement
-        self.cartographie = cartographie
-        self.commune = commune
-        self.id = id
-        self.libelle = libelle
-        self.libelle2 = libelle2
-        self.numero = numero
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Salle":
-        assert isinstance(obj, dict)
-        adresse = from_str(obj.get("adresse"))
-        adresse_complement = AdresseComplement(obj.get("adresseComplement"))
-        cartographie = Cartographie.from_dict(obj.get("cartographie"))
-        commune = Commune.from_dict(obj.get("commune"))
-        id = from_str(obj.get("id"))
-        libelle = from_str(obj.get("libelle"))
-        libelle2 = Libelle2(obj.get("libelle2"))
-        numero = int(from_str(obj.get("numero")))
-        return Salle(
-            adresse,
-            adresse_complement,
-            cartographie,
-            commune,
-            id,
-            libelle,
-            libelle2,
-            numero,
-        )
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["adresse"] = from_str(self.adresse)
-        result["adresseComplement"] = to_enum(
-            AdresseComplement, self.adresse_complement
-        )
-        result["cartographie"] = to_class(Cartographie, self.cartographie)
-        result["commune"] = to_class(Commune, self.commune)
-        result["id"] = from_str(self.id)
-        result["libelle"] = from_str(self.libelle)
-        result["libelle2"] = to_enum(Libelle2, self.libelle2)
-        result["numero"] = from_str(str(self.numero))
-        return result
 
 
 class Rencontre:

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_competitions_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_competitions_response.py
@@ -129,8 +129,6 @@ class IDEngagementEquipe:
         return result
 
 
-
-
 class Libelle(Enum):
     AIDE_MARQUEUR = "Aide marqueur"
     ARBITRE = "Arbitre"
@@ -270,8 +268,6 @@ class Libelle2(Enum):
     PARC_DES_SPORTS_POUDRERIE = "PARC DES SPORTS POUDRERIE"
     SALLE_NASARRE = "SALLE NASARRE"
     STADE_FOCH = "Stade foch"
-
-
 
 
 class Rencontre:

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_organismes_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_organismes_response.py
@@ -15,6 +15,8 @@ from ..utils.converters import (
     to_enum,
     to_float,
 )
+from .id_poule import IDPoule
+from .salle import Salle
 
 
 class Cartographie:
@@ -136,22 +138,6 @@ class Organisateur:
         return result
 
 
-class IDPoule:
-    id: str
-
-    def __init__(self, id: str) -> None:
-        self.id = id
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDPoule":
-        assert isinstance(obj, dict)
-        id = from_str(obj.get("id"))
-        return IDPoule(id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = from_str(self.id)
-        return result
 
 
 class Sexe(Enum):
@@ -572,69 +558,6 @@ class OffresPratique:
         return result
 
 
-class Salle:
-    adresse: str
-    adresse_complement: str
-    cartographie: Cartographie
-    commune: Commune
-    id: str
-    libelle: str
-    libelle2: str
-    numero: int
-
-    def __init__(
-        self,
-        adresse: str,
-        adresse_complement: str,
-        cartographie: Cartographie,
-        commune: Commune,
-        id: str,
-        libelle: str,
-        libelle2: str,
-        numero: int,
-    ) -> None:
-        self.adresse = adresse
-        self.adresse_complement = adresse_complement
-        self.cartographie = cartographie
-        self.commune = commune
-        self.id = id
-        self.libelle = libelle
-        self.libelle2 = libelle2
-        self.numero = numero
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Salle":
-        assert isinstance(obj, dict)
-        adresse = from_str(obj.get("adresse"))
-        adresse_complement = from_str(obj.get("adresseComplement"))
-        cartographie = Cartographie.from_dict(obj.get("cartographie"))
-        commune = Commune.from_dict(obj.get("commune"))
-        id = from_str(obj.get("id"))
-        libelle = from_str(obj.get("libelle"))
-        libelle2 = from_str(obj.get("libelle2"))
-        numero = int(from_str(obj.get("numero")))
-        return Salle(
-            adresse,
-            adresse_complement,
-            cartographie,
-            commune,
-            id,
-            libelle,
-            libelle2,
-            numero,
-        )
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["adresse"] = from_str(self.adresse)
-        result["adresseComplement"] = from_str(self.adresse_complement)
-        result["cartographie"] = to_class(Cartographie, self.cartographie)
-        result["commune"] = to_class(Commune, self.commune)
-        result["id"] = from_str(self.id)
-        result["libelle"] = from_str(self.libelle)
-        result["libelle2"] = from_str(self.libelle2)
-        result["numero"] = from_str(str(self.numero))
-        return result
 
 
 class Data:

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_organismes_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_organismes_response.py
@@ -138,8 +138,6 @@ class Organisateur:
         return result
 
 
-
-
 class Sexe(Enum):
     F = "F"
     M = "M"
@@ -556,8 +554,6 @@ class OffresPratique:
             FfbbserverOffresPratiquesID, self.ffbbserver_offres_pratiques_id
         )
         return result
-
-
 
 
 class Data:

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_poules_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_poules_response.py
@@ -17,6 +17,8 @@ from ..utils.converters import (
     to_enum,
     to_float,
 )
+from .id_organisme_equipe import IDOrganismeEquipe
+from .salle import Salle
 
 
 class Nom(Enum):
@@ -258,22 +260,6 @@ class Classement:
         return result
 
 
-class IDOrganismeEquipe:
-    logo: Optional[Logo]
-
-    def __init__(self, logo: Optional[Logo]) -> None:
-        self.logo = logo
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDOrganismeEquipe":
-        assert isinstance(obj, dict)
-        logo = from_union([Logo.from_dict, from_none], obj.get("logo"))
-        return IDOrganismeEquipe(logo)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["logo"] = from_union([lambda x: to_class(Logo, x), from_none], self.logo)
-        return result
 
 
 class Libelle(Enum):
@@ -411,71 +397,6 @@ class Libelle2(Enum):
     SALLE_NASARRE = "SALLE NASARRE"
 
 
-class Salle:
-    adresse: str
-    adresse_complement: AdresseComplement
-    cartographie: Cartographie
-    commune: Commune
-    id: str
-    libelle: str
-    libelle2: Libelle2
-    numero: int
-
-    def __init__(
-        self,
-        adresse: str,
-        adresse_complement: AdresseComplement,
-        cartographie: Cartographie,
-        commune: Commune,
-        id: str,
-        libelle: str,
-        libelle2: Libelle2,
-        numero: int,
-    ) -> None:
-        self.adresse = adresse
-        self.adresse_complement = adresse_complement
-        self.cartographie = cartographie
-        self.commune = commune
-        self.id = id
-        self.libelle = libelle
-        self.libelle2 = libelle2
-        self.numero = numero
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Salle":
-        assert isinstance(obj, dict)
-        adresse = from_str(obj.get("adresse"))
-        adresse_complement = AdresseComplement(obj.get("adresseComplement"))
-        cartographie = Cartographie.from_dict(obj.get("cartographie"))
-        commune = Commune.from_dict(obj.get("commune"))
-        id = from_str(obj.get("id"))
-        libelle = from_str(obj.get("libelle"))
-        libelle2 = Libelle2(obj.get("libelle2"))
-        numero = int(from_str(obj.get("numero")))
-        return Salle(
-            adresse,
-            adresse_complement,
-            cartographie,
-            commune,
-            id,
-            libelle,
-            libelle2,
-            numero,
-        )
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["adresse"] = from_str(self.adresse)
-        result["adresseComplement"] = to_enum(
-            AdresseComplement, self.adresse_complement
-        )
-        result["cartographie"] = to_class(Cartographie, self.cartographie)
-        result["commune"] = to_class(Commune, self.commune)
-        result["id"] = from_str(self.id)
-        result["libelle"] = from_str(self.libelle)
-        result["libelle2"] = to_enum(Libelle2, self.libelle2)
-        result["numero"] = from_str(str(self.numero))
-        return result
 
 
 class Rencontre:

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_poules_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_poules_response.py
@@ -260,8 +260,6 @@ class Classement:
         return result
 
 
-
-
 class Libelle(Enum):
     AIDE_MARQUEUR = "Aide marqueur"
     ARBITRE = "Arbitre"
@@ -395,8 +393,6 @@ class Libelle2(Enum):
     EMPTY = ""
     PARC_DES_SPORTS_POUDRERIE = "PARC DES SPORTS POUDRERIE"
     SALLE_NASARRE = "SALLE NASARRE"
-
-
 
 
 class Rencontre:

--- a/src/ffbb_api_client_v2/models/get_lives_json_response.py
+++ b/src/ffbb_api_client_v2/models/get_lives_json_response.py
@@ -53,9 +53,6 @@ class IDEngagementEquipe1:
         return result
 
 
-
-
-
 class ExternalID:
     competition_id: CompetitionID
     id_engagement_equipe1: IDEngagementEquipe1

--- a/src/ffbb_api_client_v2/models/get_lives_json_response.py
+++ b/src/ffbb_api_client_v2/models/get_lives_json_response.py
@@ -14,6 +14,9 @@ from ..utils.converters import (
     to_enum,
 )
 from .competition_id import CompetitionID
+from .id_organisme_equipe import IDOrganismeEquipe
+from .id_poule import IDPoule
+from .salle import Salle
 
 
 class CompetitionAbgName(Enum):
@@ -50,78 +53,7 @@ class IDEngagementEquipe1:
         return result
 
 
-class IDOrganismeEquipe:
-    id: str
-    logo: Optional[IDEngagementEquipe1]
 
-    def __init__(self, id: str, logo: Optional[IDEngagementEquipe1]) -> None:
-        self.id = id
-        self.logo = logo
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDOrganismeEquipe":
-        assert isinstance(obj, dict)
-        id = from_str(obj.get("id"))
-        logo = from_union([IDEngagementEquipe1.from_dict, from_none], obj.get("logo"))
-        return IDOrganismeEquipe(id, logo)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = from_str(self.id)
-        result["logo"] = from_union(
-            [lambda x: to_class(IDEngagementEquipe1, x), from_none], self.logo
-        )
-        return result
-
-
-class Nom(Enum):
-    GROUPE_A = "Groupe A"
-    GROUPE_B = "Groupe B"
-    POULE_A = "Poule A"
-
-
-class IDPoule:
-    id: str
-    nom: Nom
-
-    def __init__(self, id: str, nom: Nom) -> None:
-        self.id = id
-        self.nom = nom
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDPoule":
-        assert isinstance(obj, dict)
-        id = from_str(obj.get("id"))
-        nom = Nom(obj.get("nom"))
-        return IDPoule(id, nom)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = from_str(self.id)
-        result["nom"] = to_enum(Nom, self.nom)
-        return result
-
-
-class Salle:
-    libelle: str
-    libelle2: str
-
-    def __init__(self, libelle: str, libelle2: str) -> None:
-        self.libelle = libelle
-        self.libelle2 = libelle2
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Salle":
-        assert isinstance(obj, dict)
-        libelle = from_str(obj.get("libelle"))
-        libelle2 = from_str(obj.get("libelle2"))
-        return Salle(libelle, libelle2)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["libelle"] = from_str(self.libelle)
-        result["libelle2"] = from_str(self.libelle2)
-        return result
 
 
 class ExternalID:

--- a/src/ffbb_api_client_v2/models/post_multi_search_response.py
+++ b/src/ffbb_api_client_v2/models/post_multi_search_response.py
@@ -1776,8 +1776,6 @@ class NomClubPro(Enum):
     VANVES_GPSO_BASKET = "VANVES GPSO BASKET"
 
 
-
-
 class Jour(Enum):
     DIMANCHE = "dimanche"
     JEUDI = "jeudi"
@@ -2423,8 +2421,6 @@ class Saison:
         result: dict = {}
         result["code"] = to_enum(SaisonCode, self.code)
         return result
-
-
 
 
 class HitStatus(Enum):

--- a/src/ffbb_api_client_v2/models/post_multi_search_response.py
+++ b/src/ffbb_api_client_v2/models/post_multi_search_response.py
@@ -19,6 +19,9 @@ from ..utils.converters import (
     to_enum,
     to_float,
 )
+from .id_organisme_equipe import IDOrganismeEquipe
+from .id_poule import IDPoule
+from .salle import Salle
 
 
 class CompetitionIDSexe:
@@ -1773,74 +1776,6 @@ class NomClubPro(Enum):
     VANVES_GPSO_BASKET = "VANVES GPSO BASKET"
 
 
-class IDOrganismeEquipe:
-    code: str
-    id: str
-    logo: Optional[Logo]
-    nom: str
-    nom_simple: None
-    nom_club_pro: Optional[NomClubPro]
-
-    def __init__(
-        self,
-        code: str,
-        id: str,
-        logo: Optional[Logo],
-        nom: str,
-        nom_simple: None,
-        nom_club_pro: Optional[NomClubPro],
-    ) -> None:
-        self.code = code
-        self.id = id
-        self.logo = logo
-        self.nom = nom
-        self.nom_simple = nom_simple
-        self.nom_club_pro = nom_club_pro
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDOrganismeEquipe":
-        assert isinstance(obj, dict)
-        code = from_str(obj.get("code"))
-        id = from_str(obj.get("id"))
-        logo = from_union([Logo.from_dict, from_none], obj.get("logo"))
-        nom = from_str(obj.get("nom"))
-        nom_simple = from_none(obj.get("nom_simple"))
-        nom_club_pro = from_union([from_none, NomClubPro], obj.get("nomClubPro"))
-        return IDOrganismeEquipe(code, id, logo, nom, nom_simple, nom_club_pro)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["code"] = from_str(self.code)
-        result["id"] = from_str(self.id)
-        result["logo"] = from_union([lambda x: to_class(Logo, x), from_none], self.logo)
-        result["nom"] = from_str(self.nom)
-        result["nom_simple"] = from_none(self.nom_simple)
-        result["nomClubPro"] = from_union(
-            [from_none, lambda x: to_enum(NomClubPro, x)], self.nom_club_pro
-        )
-        return result
-
-
-class IDPoule:
-    id: str
-    nom: str
-
-    def __init__(self, id: str, nom: str) -> None:
-        self.id = id
-        self.nom = nom
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDPoule":
-        assert isinstance(obj, dict)
-        id = from_str(obj.get("id"))
-        nom = from_str(obj.get("nom"))
-        return IDPoule(id, nom)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = from_str(self.id)
-        result["nom"] = from_str(self.nom)
-        return result
 
 
 class Jour(Enum):
@@ -2490,53 +2425,6 @@ class Saison:
         return result
 
 
-class Salle:
-    adresse: Optional[str]
-    adresse_complement: Optional[str]
-    cartographie: Optional[Cartographie]
-    id: str
-    libelle: str
-
-    def __init__(
-        self,
-        adresse: Optional[str],
-        adresse_complement: Optional[str],
-        cartographie: Optional[Cartographie],
-        id: str,
-        libelle: str,
-    ) -> None:
-        self.adresse = adresse
-        self.adresse_complement = adresse_complement
-        self.cartographie = cartographie
-        self.id = id
-        self.libelle = libelle
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Salle":
-        assert isinstance(obj, dict)
-        adresse = from_union([from_none, from_str], obj.get("adresse"))
-        adresse_complement = from_union(
-            [from_none, from_str], obj.get("adresseComplement")
-        )
-        cartographie = from_union(
-            [Cartographie.from_dict, from_none], obj.get("cartographie")
-        )
-        id = from_str(obj.get("id"))
-        libelle = from_str(obj.get("libelle"))
-        return Salle(adresse, adresse_complement, cartographie, id, libelle)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["adresse"] = from_union([from_none, from_str], self.adresse)
-        result["adresseComplement"] = from_union(
-            [from_none, from_str], self.adresse_complement
-        )
-        result["cartographie"] = from_union(
-            [lambda x: to_class(Cartographie, x), from_none], self.cartographie
-        )
-        result["id"] = from_str(self.id)
-        result["libelle"] = from_str(self.libelle)
-        return result
 
 
 class HitStatus(Enum):


### PR DESCRIPTION
## Summary
- drop private IDPoule/IDOrganismeEquipe/Salle classes
- import canonical versions in response models

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684857f59954832b905e7282f4854385