### PR TITLE
Refactor models to import canonical classes

### DIFF
--- a/src/ffbb_api_client_v2/models/get_ffbbserver_competitions_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_competitions_response.py
@@ -17,31 +17,14 @@ from ..utils.converters import (
     to_enum,
     to_float,
 )
+from .categorie import Categorie
+from .cartographie import Cartographie
+from .commune import Commune
+from .id_organisme_equipe import IDOrganismeEquipe
+from .logo import Logo
+from .salle import Salle
 
 
-class Categorie:
-    code: str
-    ordre: int
-
-    def __init__(self, code: str, ordre: int) -> None:
-        self.code = code
-        self.ordre = ordre
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Categorie":
-        assert isinstance(obj, dict)
-        code = from_str(obj.get("code"))
-        ordre = from_int(obj.get("ordre"))
-        return Categorie(code, ordre)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["code"] = from_str(self.code)
-        result["ordre"] = from_int(self.ordre)
-        return result
-
-
-class IDOrganisme:
     id: str
 
     def __init__(self, id: str) -> None:
@@ -127,27 +110,6 @@ class IDEngagementEquipe:
         return result
 
 
-class IDOrganismeEquipe:
-    logo: Optional[IDOrganisme]
-
-    def __init__(self, logo: Optional[IDOrganisme]) -> None:
-        self.logo = logo
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDOrganismeEquipe":
-        assert isinstance(obj, dict)
-        logo = from_union([IDOrganisme.from_dict, from_none], obj.get("logo"))
-        return IDOrganismeEquipe(logo)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["logo"] = from_union(
-            [lambda x: to_class(IDOrganisme, x), from_none], self.logo
-        )
-        return result
-
-
-class Libelle(Enum):
     AIDE_MARQUEUR = "Aide marqueur"
     ARBITRE = "Arbitre"
     CHRONOMETREUR = "Chronometreur"
@@ -235,51 +197,6 @@ class AdresseComplement(Enum):
     MONTFAVET = "MONTFAVET"
 
 
-class Cartographie:
-    latitude: float
-    longitude: float
-
-    def __init__(self, latitude: float, longitude: float) -> None:
-        self.latitude = latitude
-        self.longitude = longitude
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Cartographie":
-        assert isinstance(obj, dict)
-        latitude = from_float(obj.get("latitude"))
-        longitude = from_float(obj.get("longitude"))
-        return Cartographie(latitude, longitude)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["latitude"] = to_float(self.latitude)
-        result["longitude"] = to_float(self.longitude)
-        return result
-
-
-class Commune:
-    code_postal: str
-    libelle: str
-
-    def __init__(self, code_postal: str, libelle: str) -> None:
-        self.code_postal = code_postal
-        self.libelle = libelle
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Commune":
-        assert isinstance(obj, dict)
-        code_postal = from_str(obj.get("codePostal"))
-        libelle = from_str(obj.get("libelle"))
-        return Commune(code_postal, libelle)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["codePostal"] = from_str(self.code_postal)
-        result["libelle"] = from_str(self.libelle)
-        return result
-
-
-class Libelle2(Enum):
     ANCIEN_GYMNASE_DE_LA_BARBIERE = "ancien GYMNASE DE LA BARBIERE"
     EMPTY = ""
     GYMNASE_LA_PIOLINE = "Gymnase La Pioline"
@@ -288,74 +205,6 @@ class Libelle2(Enum):
     STADE_FOCH = "Stade foch"
 
 
-class Salle:
-    adresse: str
-    adresse_complement: AdresseComplement
-    cartographie: Cartographie
-    commune: Commune
-    id: str
-    libelle: str
-    libelle2: Libelle2
-    numero: int
-
-    def __init__(
-        self,
-        adresse: str,
-        adresse_complement: AdresseComplement,
-        cartographie: Cartographie,
-        commune: Commune,
-        id: str,
-        libelle: str,
-        libelle2: Libelle2,
-        numero: int,
-    ) -> None:
-        self.adresse = adresse
-        self.adresse_complement = adresse_complement
-        self.cartographie = cartographie
-        self.commune = commune
-        self.id = id
-        self.libelle = libelle
-        self.libelle2 = libelle2
-        self.numero = numero
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Salle":
-        assert isinstance(obj, dict)
-        adresse = from_str(obj.get("adresse"))
-        adresse_complement = AdresseComplement(obj.get("adresseComplement"))
-        cartographie = Cartographie.from_dict(obj.get("cartographie"))
-        commune = Commune.from_dict(obj.get("commune"))
-        id = from_str(obj.get("id"))
-        libelle = from_str(obj.get("libelle"))
-        libelle2 = Libelle2(obj.get("libelle2"))
-        numero = int(from_str(obj.get("numero")))
-        return Salle(
-            adresse,
-            adresse_complement,
-            cartographie,
-            commune,
-            id,
-            libelle,
-            libelle2,
-            numero,
-        )
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["adresse"] = from_str(self.adresse)
-        result["adresseComplement"] = to_enum(
-            AdresseComplement, self.adresse_complement
-        )
-        result["cartographie"] = to_class(Cartographie, self.cartographie)
-        result["commune"] = to_class(Commune, self.commune)
-        result["id"] = from_str(self.id)
-        result["libelle"] = from_str(self.libelle)
-        result["libelle2"] = to_enum(Libelle2, self.libelle2)
-        result["numero"] = from_str(str(self.numero))
-        return result
-
-
-class Rencontre:
     competition_id: str
     date_rencontre: datetime
     gs_id: None
@@ -619,29 +468,6 @@ class DataPoule:
         return result
 
 
-class Logo:
-    gradient_color: str
-    id: UUID
-
-    def __init__(self, gradient_color: str, id: UUID) -> None:
-        self.gradient_color = gradient_color
-        self.id = id
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Logo":
-        assert isinstance(obj, dict)
-        gradient_color = from_str(obj.get("gradient_color"))
-        id = UUID(obj.get("id"))
-        return Logo(gradient_color, id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["gradient_color"] = from_str(self.gradient_color)
-        result["id"] = str(self.id)
-        return result
-
-
-class TypeCompetitionGenerique:
     logo: Logo
 
     def __init__(self, logo: Logo) -> None:

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_organismes_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_organismes_response.py
@@ -15,50 +15,12 @@ from ..utils.converters import (
     to_enum,
     to_float,
 )
-
-
-class Cartographie:
-    latitude: float
-    longitude: float
-
-    def __init__(self, latitude: float, longitude: float) -> None:
-        self.latitude = latitude
-        self.longitude = longitude
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Cartographie":
-        assert isinstance(obj, dict)
-        latitude = from_float(obj.get("latitude"))
-        longitude = from_float(obj.get("longitude"))
-        return Cartographie(latitude, longitude)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["latitude"] = to_float(self.latitude)
-        result["longitude"] = to_float(self.longitude)
-        return result
-
-
-class Commune:
-    code_postal: int
-    libelle: str
-
-    def __init__(self, code_postal: int, libelle: str) -> None:
-        self.code_postal = code_postal
-        self.libelle = libelle
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Commune":
-        assert isinstance(obj, dict)
-        code_postal = int(from_str(obj.get("codePostal")))
-        libelle = from_str(obj.get("libelle"))
-        return Commune(code_postal, libelle)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["codePostal"] = from_str(str(self.code_postal))
-        result["libelle"] = from_str(self.libelle)
-        return result
+from .categorie import Categorie
+from .cartographie import Cartographie
+from .commune import Commune
+from .id_poule import IDPoule
+from .logo import Logo
+from .salle import Salle
 
 
 class Code(Enum):
@@ -67,28 +29,6 @@ class Code(Enum):
     U13 = "U13"
     U15 = "U15"
     U17 = "U17"
-
-
-class Categorie:
-    code: Code
-    ordre: int
-
-    def __init__(self, code: Code, ordre: int) -> None:
-        self.code = code
-        self.ordre = ordre
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Categorie":
-        assert isinstance(obj, dict)
-        code = Code(obj.get("code"))
-        ordre = from_int(obj.get("ordre"))
-        return Categorie(code, ordre)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["code"] = to_enum(Code, self.code)
-        result["ordre"] = from_int(self.ordre)
-        return result
 
 
 class IDCompetitionPere:
@@ -136,24 +76,6 @@ class Organisateur:
         return result
 
 
-class IDPoule:
-    id: str
-
-    def __init__(self, id: str) -> None:
-        self.id = id
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDPoule":
-        assert isinstance(obj, dict)
-        id = from_str(obj.get("id"))
-        return IDPoule(id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = from_str(self.id)
-        return result
-
-
 class Sexe(Enum):
     F = "F"
     M = "M"
@@ -164,35 +86,6 @@ class TypeCompetition(Enum):
     COUPE = "COUPE"
     DIV = "DIV"
     PLAT = "PLAT"
-
-
-class GradientColor(Enum):
-    EB6_D88 = "#EB6D88"
-    ED3833 = "#ed3833"
-    THE_00_B5_EA = "#00B5EA"
-    THE_04378_B = "#04378B"
-
-
-class Logo:
-    gradient_color: GradientColor
-    id: UUID
-
-    def __init__(self, gradient_color: GradientColor, id: UUID) -> None:
-        self.gradient_color = gradient_color
-        self.id = id
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Logo":
-        assert isinstance(obj, dict)
-        gradient_color = GradientColor(obj.get("gradient_color"))
-        id = UUID(obj.get("id"))
-        return Logo(gradient_color, id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["gradient_color"] = to_enum(GradientColor, self.gradient_color)
-        result["id"] = str(self.id)
-        return result
 
 
 class TypeCompetitionGenerique:
@@ -569,71 +462,6 @@ class OffresPratique:
         result["ffbbserver_offres_pratiques_id"] = to_class(
             FfbbserverOffresPratiquesID, self.ffbbserver_offres_pratiques_id
         )
-        return result
-
-
-class Salle:
-    adresse: str
-    adresse_complement: str
-    cartographie: Cartographie
-    commune: Commune
-    id: str
-    libelle: str
-    libelle2: str
-    numero: int
-
-    def __init__(
-        self,
-        adresse: str,
-        adresse_complement: str,
-        cartographie: Cartographie,
-        commune: Commune,
-        id: str,
-        libelle: str,
-        libelle2: str,
-        numero: int,
-    ) -> None:
-        self.adresse = adresse
-        self.adresse_complement = adresse_complement
-        self.cartographie = cartographie
-        self.commune = commune
-        self.id = id
-        self.libelle = libelle
-        self.libelle2 = libelle2
-        self.numero = numero
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Salle":
-        assert isinstance(obj, dict)
-        adresse = from_str(obj.get("adresse"))
-        adresse_complement = from_str(obj.get("adresseComplement"))
-        cartographie = Cartographie.from_dict(obj.get("cartographie"))
-        commune = Commune.from_dict(obj.get("commune"))
-        id = from_str(obj.get("id"))
-        libelle = from_str(obj.get("libelle"))
-        libelle2 = from_str(obj.get("libelle2"))
-        numero = int(from_str(obj.get("numero")))
-        return Salle(
-            adresse,
-            adresse_complement,
-            cartographie,
-            commune,
-            id,
-            libelle,
-            libelle2,
-            numero,
-        )
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["adresse"] = from_str(self.adresse)
-        result["adresseComplement"] = from_str(self.adresse_complement)
-        result["cartographie"] = to_class(Cartographie, self.cartographie)
-        result["commune"] = to_class(Commune, self.commune)
-        result["id"] = from_str(self.id)
-        result["libelle"] = from_str(self.libelle)
-        result["libelle2"] = from_str(self.libelle2)
-        result["numero"] = from_str(str(self.numero))
         return result
 
 

--- a/src/ffbb_api_client_v2/models/get_ffbbserver_poules_response.py
+++ b/src/ffbb_api_client_v2/models/get_ffbbserver_poules_response.py
@@ -17,6 +17,11 @@ from ..utils.converters import (
     to_enum,
     to_float,
 )
+from .cartographie import Cartographie
+from .commune import Commune
+from .id_organisme_equipe import IDOrganismeEquipe
+from .logo import Logo
+from .salle import Salle
 
 
 class Nom(Enum):
@@ -75,25 +80,6 @@ class IDEngagement:
         return result
 
 
-class Logo:
-    id: UUID
-
-    def __init__(self, id: UUID) -> None:
-        self.id = id
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Logo":
-        assert isinstance(obj, dict)
-        id = UUID(obj.get("id"))
-        return Logo(id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = str(self.id)
-        return result
-
-
-class Organisme:
     logo: Optional[Logo]
     nom: Nom
 
@@ -258,25 +244,6 @@ class Classement:
         return result
 
 
-class IDOrganismeEquipe:
-    logo: Optional[Logo]
-
-    def __init__(self, logo: Optional[Logo]) -> None:
-        self.logo = logo
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDOrganismeEquipe":
-        assert isinstance(obj, dict)
-        logo = from_union([Logo.from_dict, from_none], obj.get("logo"))
-        return IDOrganismeEquipe(logo)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["logo"] = from_union([lambda x: to_class(Logo, x), from_none], self.logo)
-        return result
-
-
-class Libelle(Enum):
     AIDE_MARQUEUR = "Aide marqueur"
     ARBITRE = "Arbitre"
     CHRONOMETREUR = "Chronometreur"
@@ -361,29 +328,6 @@ class AdresseComplement(Enum):
     MONTFAVET = "MONTFAVET"
 
 
-class Cartographie:
-    latitude: float
-    longitude: float
-
-    def __init__(self, latitude: float, longitude: float) -> None:
-        self.latitude = latitude
-        self.longitude = longitude
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Cartographie":
-        assert isinstance(obj, dict)
-        latitude = from_float(obj.get("latitude"))
-        longitude = from_float(obj.get("longitude"))
-        return Cartographie(latitude, longitude)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["latitude"] = to_float(self.latitude)
-        result["longitude"] = to_float(self.longitude)
-        return result
-
-
-class Commune:
     code_postal: str
     libelle: str
 
@@ -411,74 +355,6 @@ class Libelle2(Enum):
     SALLE_NASARRE = "SALLE NASARRE"
 
 
-class Salle:
-    adresse: str
-    adresse_complement: AdresseComplement
-    cartographie: Cartographie
-    commune: Commune
-    id: str
-    libelle: str
-    libelle2: Libelle2
-    numero: int
-
-    def __init__(
-        self,
-        adresse: str,
-        adresse_complement: AdresseComplement,
-        cartographie: Cartographie,
-        commune: Commune,
-        id: str,
-        libelle: str,
-        libelle2: Libelle2,
-        numero: int,
-    ) -> None:
-        self.adresse = adresse
-        self.adresse_complement = adresse_complement
-        self.cartographie = cartographie
-        self.commune = commune
-        self.id = id
-        self.libelle = libelle
-        self.libelle2 = libelle2
-        self.numero = numero
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Salle":
-        assert isinstance(obj, dict)
-        adresse = from_str(obj.get("adresse"))
-        adresse_complement = AdresseComplement(obj.get("adresseComplement"))
-        cartographie = Cartographie.from_dict(obj.get("cartographie"))
-        commune = Commune.from_dict(obj.get("commune"))
-        id = from_str(obj.get("id"))
-        libelle = from_str(obj.get("libelle"))
-        libelle2 = Libelle2(obj.get("libelle2"))
-        numero = int(from_str(obj.get("numero")))
-        return Salle(
-            adresse,
-            adresse_complement,
-            cartographie,
-            commune,
-            id,
-            libelle,
-            libelle2,
-            numero,
-        )
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["adresse"] = from_str(self.adresse)
-        result["adresseComplement"] = to_enum(
-            AdresseComplement, self.adresse_complement
-        )
-        result["cartographie"] = to_class(Cartographie, self.cartographie)
-        result["commune"] = to_class(Commune, self.commune)
-        result["id"] = from_str(self.id)
-        result["libelle"] = from_str(self.libelle)
-        result["libelle2"] = to_enum(Libelle2, self.libelle2)
-        result["numero"] = from_str(str(self.numero))
-        return result
-
-
-class Rencontre:
     competition_id: str
     date_rencontre: datetime
     gs_id: None

--- a/src/ffbb_api_client_v2/models/get_lives_json_response.py
+++ b/src/ffbb_api_client_v2/models/get_lives_json_response.py
@@ -14,6 +14,9 @@ from ..utils.converters import (
     to_enum,
 )
 from .competition_id import CompetitionID
+from .id_organisme_equipe import IDOrganismeEquipe
+from .id_poule import IDPoule
+from .salle import Salle
 
 
 class CompetitionAbgName(Enum):
@@ -50,78 +53,10 @@ class IDEngagementEquipe1:
         return result
 
 
-class IDOrganismeEquipe:
-    id: str
-    logo: Optional[IDEngagementEquipe1]
-
-    def __init__(self, id: str, logo: Optional[IDEngagementEquipe1]) -> None:
-        self.id = id
-        self.logo = logo
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDOrganismeEquipe":
-        assert isinstance(obj, dict)
-        id = from_str(obj.get("id"))
-        logo = from_union([IDEngagementEquipe1.from_dict, from_none], obj.get("logo"))
-        return IDOrganismeEquipe(id, logo)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = from_str(self.id)
-        result["logo"] = from_union(
-            [lambda x: to_class(IDEngagementEquipe1, x), from_none], self.logo
-        )
-        return result
-
-
 class Nom(Enum):
     GROUPE_A = "Groupe A"
     GROUPE_B = "Groupe B"
     POULE_A = "Poule A"
-
-
-class IDPoule:
-    id: str
-    nom: Nom
-
-    def __init__(self, id: str, nom: Nom) -> None:
-        self.id = id
-        self.nom = nom
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDPoule":
-        assert isinstance(obj, dict)
-        id = from_str(obj.get("id"))
-        nom = Nom(obj.get("nom"))
-        return IDPoule(id, nom)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = from_str(self.id)
-        result["nom"] = to_enum(Nom, self.nom)
-        return result
-
-
-class Salle:
-    libelle: str
-    libelle2: str
-
-    def __init__(self, libelle: str, libelle2: str) -> None:
-        self.libelle = libelle
-        self.libelle2 = libelle2
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Salle":
-        assert isinstance(obj, dict)
-        libelle = from_str(obj.get("libelle"))
-        libelle2 = from_str(obj.get("libelle2"))
-        return Salle(libelle, libelle2)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["libelle"] = from_str(self.libelle)
-        result["libelle2"] = from_str(self.libelle2)
-        return result
 
 
 class ExternalID:

--- a/src/ffbb_api_client_v2/models/multi_search_result_pratiques.py
+++ b/src/ffbb_api_client_v2/models/multi_search_result_pratiques.py
@@ -18,6 +18,7 @@ from ..utils.converters import (
     to_float,
 )
 from .facet_distribution import FacetDistribution
+from .cartographie import Cartographie
 from .facet_stats import FacetStats
 from .hit import Hit
 
@@ -214,107 +215,6 @@ class Status(Enum):
     DRAFT = "draft"
 
 
-class Cartographie:
-    adresse: Optional[str] = None
-    code_postal: Optional[str] = None
-    coordonnees: Optional[Coordonnees] = None
-    date_created: None
-    date_updated: None
-    id: Optional[str] = None
-    latitude: Optional[float] = None
-    longitude: Optional[float] = None
-    title: Optional[str] = None
-    ville: Optional[str] = None
-    status: Optional[Status] = None
-
-    def __init__(
-        self,
-        adresse: Optional[str],
-        code_postal: Optional[str],
-        coordonnees: Optional[Coordonnees],
-        date_created: None,
-        date_updated: None,
-        id: Optional[str],
-        latitude: Optional[float],
-        longitude: Optional[float],
-        title: Optional[str],
-        ville: Optional[str],
-        status: Optional[Status] = None,
-    ) -> None:
-        self.adresse = adresse
-        self.code_postal = code_postal
-        self.coordonnees = coordonnees
-        self.date_created = date_created
-        self.date_updated = date_updated
-        self.id = id
-        self.latitude = latitude
-        self.longitude = longitude
-        self.title = title
-        self.ville = ville
-        self.status = status
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Cartographie":
-        assert isinstance(obj, dict)
-        adresse = from_union([from_str, from_none], obj.get("adresse"))
-        code_postal = from_union([from_str, from_none], obj.get("codePostal"))
-        coordonnees = from_union(
-            [Coordonnees.from_dict, from_none], obj.get("coordonnees")
-        )
-        date_created = from_none(obj.get("date_created"))
-        date_updated = from_none(obj.get("date_updated"))
-        id = from_union([from_str, from_none], obj.get("id"))
-        latitude = from_union([from_float, from_none], obj.get("latitude"))
-        longitude = from_union([from_float, from_none], obj.get("longitude"))
-        title = from_union([from_str, from_none], obj.get("title"))
-        ville = from_union([from_str, from_none], obj.get("ville"))
-        status = from_union([Status, from_none], obj.get("status"))
-        return Cartographie(
-            adresse,
-            code_postal,
-            coordonnees,
-            date_created,
-            date_updated,
-            id,
-            latitude,
-            longitude,
-            title,
-            ville,
-            status,
-        )
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.adresse is not None:
-            result["adresse"] = from_union([from_str, from_none], self.adresse)
-        if self.code_postal is not None:
-            result["codePostal"] = from_union([from_str, from_none], self.code_postal)
-        if self.coordonnees is not None:
-            result["coordonnees"] = from_union(
-                [lambda x: to_class(Coordonnees, x), from_none], self.coordonnees
-            )
-        if self.date_created is not None:
-            result["date_created"] = from_none(self.date_created)
-        if self.date_updated is not None:
-            result["date_updated"] = from_none(self.date_updated)
-        if self.id is not None:
-            result["id"] = from_union([from_str, from_none], self.id)
-        if self.latitude is not None:
-            result["latitude"] = from_union([to_float, from_none], self.latitude)
-        if self.longitude is not None:
-            result["longitude"] = from_union([to_float, from_none], self.longitude)
-        if self.title is not None:
-            result["title"] = from_union([from_str, from_none], self.title)
-        if self.ville is not None:
-            result["ville"] = from_union([from_str, from_none], self.ville)
-        if self.status is not None:
-            result["status"] = from_union(
-                [lambda x: to_enum(Status, x), from_none], self.status
-            )
-        return result
-
-
-class Geo:
     lat: Optional[float] = None
     lng: Optional[float] = None
 

--- a/src/ffbb_api_client_v2/models/post_multi_search_response.py
+++ b/src/ffbb_api_client_v2/models/post_multi_search_response.py
@@ -19,6 +19,12 @@ from ..utils.converters import (
     to_enum,
     to_float,
 )
+from .cartographie import Cartographie
+from .commune import Commune
+from .id_organisme_equipe import IDOrganismeEquipe
+from .id_poule import IDPoule
+from .logo import Logo
+from .salle import Salle
 
 
 class CompetitionIDSexe:
@@ -550,94 +556,6 @@ class Coordonnees:
         return result
 
 
-class CartographieStatus(Enum):
-    DRAFT = "draft"
-
-
-class Cartographie:
-    adresse: Optional[str]
-    code_postal: str
-    coordonnees: Coordonnees
-    date_created: None
-    date_updated: None
-    id: str
-    latitude: float
-    longitude: float
-    status: CartographieStatus
-    title: Optional[str]
-    ville: str
-
-    def __init__(
-        self,
-        adresse: Optional[str],
-        code_postal: str,
-        coordonnees: Coordonnees,
-        date_created: None,
-        date_updated: None,
-        id: str,
-        latitude: float,
-        longitude: float,
-        status: CartographieStatus,
-        title: Optional[str],
-        ville: str,
-    ) -> None:
-        self.adresse = adresse
-        self.code_postal = code_postal
-        self.coordonnees = coordonnees
-        self.date_created = date_created
-        self.date_updated = date_updated
-        self.id = id
-        self.latitude = latitude
-        self.longitude = longitude
-        self.status = status
-        self.title = title
-        self.ville = ville
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Cartographie":
-        assert isinstance(obj, dict)
-        adresse = from_union([from_none, from_str], obj.get("adresse"))
-        code_postal = from_str(obj.get("codePostal"))
-        coordonnees = Coordonnees.from_dict(obj.get("coordonnees"))
-        date_created = from_none(obj.get("date_created"))
-        date_updated = from_none(obj.get("date_updated"))
-        id = from_str(obj.get("id"))
-        latitude = from_float(obj.get("latitude"))
-        longitude = from_float(obj.get("longitude"))
-        status = CartographieStatus(obj.get("status"))
-        title = from_union([from_none, from_str], obj.get("title"))
-        ville = from_str(obj.get("ville"))
-        return Cartographie(
-            adresse,
-            code_postal,
-            coordonnees,
-            date_created,
-            date_updated,
-            id,
-            latitude,
-            longitude,
-            status,
-            title,
-            ville,
-        )
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["adresse"] = from_union([from_none, from_str], self.adresse)
-        result["codePostal"] = from_str(self.code_postal)
-        result["coordonnees"] = to_class(Coordonnees, self.coordonnees)
-        result["date_created"] = from_none(self.date_created)
-        result["date_updated"] = from_none(self.date_updated)
-        result["id"] = from_str(self.id)
-        result["latitude"] = to_float(self.latitude)
-        result["longitude"] = to_float(self.longitude)
-        result["status"] = to_enum(CartographieStatus, self.status)
-        result["title"] = from_union([from_none, from_str], self.title)
-        result["ville"] = from_str(self.ville)
-        return result
-
-
-class CategorieCode(Enum):
     BIT = "BIT"
     BT = "BT"
     EBT = "EBT"
@@ -879,74 +797,6 @@ class Departement(Enum):
     YVELINES = "Yvelines"
 
 
-class Commune:
-    code_insee: None
-    code_postal: str
-    date_created: Optional[datetime]
-    date_updated: Optional[datetime]
-    departement: Departement
-    id: Optional[str]
-    libelle: str
-
-    def __init__(
-        self,
-        code_insee: None,
-        code_postal: str,
-        date_created: Optional[datetime],
-        date_updated: Optional[datetime],
-        departement: Departement,
-        id: Optional[str],
-        libelle: str,
-    ) -> None:
-        self.code_insee = code_insee
-        self.code_postal = code_postal
-        self.date_created = date_created
-        self.date_updated = date_updated
-        self.departement = departement
-        self.id = id
-        self.libelle = libelle
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Commune":
-        assert isinstance(obj, dict)
-        code_insee = from_none(obj.get("codeInsee"))
-        code_postal = from_str(obj.get("codePostal"))
-        date_created = from_union([from_datetime, from_none], obj.get("date_created"))
-        date_updated = from_union([from_datetime, from_none], obj.get("date_updated"))
-        departement = Departement(obj.get("departement"))
-        id = from_union([from_str, from_none], obj.get("id"))
-        libelle = from_str(obj.get("libelle"))
-        return Commune(
-            code_insee,
-            code_postal,
-            date_created,
-            date_updated,
-            departement,
-            id,
-            libelle,
-        )
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.code_insee is not None:
-            result["codeInsee"] = from_none(self.code_insee)
-        result["codePostal"] = from_str(self.code_postal)
-        if self.date_created is not None:
-            result["date_created"] = from_union(
-                [lambda x: x.isoformat(), from_none], self.date_created
-            )
-        if self.date_updated is not None:
-            result["date_updated"] = from_union(
-                [lambda x: x.isoformat(), from_none], self.date_updated
-            )
-        result["departement"] = to_enum(Departement, self.departement)
-        if self.id is not None:
-            result["id"] = from_union([from_str, from_none], self.id)
-        result["libelle"] = from_str(self.libelle)
-        return result
-
-
-class CommuneClubPro:
     code_postal: str
     departement: Departement
     libelle: str
@@ -1147,29 +997,6 @@ class CompetitionIDTypeCompetitionEnum(Enum):
     PLATEAU = "Plateau"
 
 
-class Logo:
-    gradient_color: str
-    id: UUID
-
-    def __init__(self, gradient_color: str, id: UUID) -> None:
-        self.gradient_color = gradient_color
-        self.id = id
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Logo":
-        assert isinstance(obj, dict)
-        gradient_color = from_str(obj.get("gradient_color"))
-        id = UUID(obj.get("id"))
-        return Logo(gradient_color, id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["gradient_color"] = from_str(self.gradient_color)
-        result["id"] = str(self.id)
-        return result
-
-
-class CompetitionIDTypeCompetitionGenerique:
     logo: Logo
 
     def __init__(self, logo: Logo) -> None:
@@ -1773,55 +1600,6 @@ class NomClubPro(Enum):
     VANVES_GPSO_BASKET = "VANVES GPSO BASKET"
 
 
-class IDOrganismeEquipe:
-    code: str
-    id: str
-    logo: Optional[Logo]
-    nom: str
-    nom_simple: None
-    nom_club_pro: Optional[NomClubPro]
-
-    def __init__(
-        self,
-        code: str,
-        id: str,
-        logo: Optional[Logo],
-        nom: str,
-        nom_simple: None,
-        nom_club_pro: Optional[NomClubPro],
-    ) -> None:
-        self.code = code
-        self.id = id
-        self.logo = logo
-        self.nom = nom
-        self.nom_simple = nom_simple
-        self.nom_club_pro = nom_club_pro
-
-    @staticmethod
-    def from_dict(obj: Any) -> "IDOrganismeEquipe":
-        assert isinstance(obj, dict)
-        code = from_str(obj.get("code"))
-        id = from_str(obj.get("id"))
-        logo = from_union([Logo.from_dict, from_none], obj.get("logo"))
-        nom = from_str(obj.get("nom"))
-        nom_simple = from_none(obj.get("nom_simple"))
-        nom_club_pro = from_union([from_none, NomClubPro], obj.get("nomClubPro"))
-        return IDOrganismeEquipe(code, id, logo, nom, nom_simple, nom_club_pro)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["code"] = from_str(self.code)
-        result["id"] = from_str(self.id)
-        result["logo"] = from_union([lambda x: to_class(Logo, x), from_none], self.logo)
-        result["nom"] = from_str(self.nom)
-        result["nom_simple"] = from_none(self.nom_simple)
-        result["nomClubPro"] = from_union(
-            [from_none, lambda x: to_enum(NomClubPro, x)], self.nom_club_pro
-        )
-        return result
-
-
-class IDPoule:
     id: str
     nom: str
 
@@ -2490,56 +2268,6 @@ class Saison:
         return result
 
 
-class Salle:
-    adresse: Optional[str]
-    adresse_complement: Optional[str]
-    cartographie: Optional[Cartographie]
-    id: str
-    libelle: str
-
-    def __init__(
-        self,
-        adresse: Optional[str],
-        adresse_complement: Optional[str],
-        cartographie: Optional[Cartographie],
-        id: str,
-        libelle: str,
-    ) -> None:
-        self.adresse = adresse
-        self.adresse_complement = adresse_complement
-        self.cartographie = cartographie
-        self.id = id
-        self.libelle = libelle
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Salle":
-        assert isinstance(obj, dict)
-        adresse = from_union([from_none, from_str], obj.get("adresse"))
-        adresse_complement = from_union(
-            [from_none, from_str], obj.get("adresseComplement")
-        )
-        cartographie = from_union(
-            [Cartographie.from_dict, from_none], obj.get("cartographie")
-        )
-        id = from_str(obj.get("id"))
-        libelle = from_str(obj.get("libelle"))
-        return Salle(adresse, adresse_complement, cartographie, id, libelle)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["adresse"] = from_union([from_none, from_str], self.adresse)
-        result["adresseComplement"] = from_union(
-            [from_none, from_str], self.adresse_complement
-        )
-        result["cartographie"] = from_union(
-            [lambda x: to_class(Cartographie, x), from_none], self.cartographie
-        )
-        result["id"] = from_str(self.id)
-        result["libelle"] = from_str(self.libelle)
-        return result
-
-
-class HitStatus(Enum):
     PUBLISHED = "published"
 
 


### PR DESCRIPTION
## Summary
- remove duplicated model classes in server responses
- use canonical classes from dedicated modules

## Testing
- `pip install pytest-cov`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684857f3f9e0832b8abc391c08c2fcb5