### PR TITLE
fix(config): add gitleaks and refine openspec domain context

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,6 +95,11 @@ repos:
   - id: commitizen
     stages: [commit-msg]
 
+- repo: https://github.com/gitleaks/gitleaks
+  rev: v8.30.0
+  hooks:
+  - id: gitleaks
+
 # Check for misspells in documentation files:
 # - repo: https://github.com/codespell-project/codespell
 #   rev: v2.2.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,9 +96,10 @@ repos:
     stages: [commit-msg]
 
 - repo: https://github.com/gitleaks/gitleaks
-  rev: v8.30.0
+  rev: v8.21.2
   hooks:
   - id: gitleaks
+    args: ['--redact', '-c', '.gitleaks.toml']
 
 # Check for misspells in documentation files:
 # - repo: https://github.com/codespell-project/codespell

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -1,7 +1,7 @@
 # Project Context
 
 ## Purpose
-FFBBApiClientV2_Python is a python project.
+Python client library for the FFBB (Federation Francaise de Basketball) API v2. Provides a unified facade over Directus REST API (14 collections) and Meilisearch full-text search (9 indexes) for accessing French basketball data: clubs, teams, competitions, matches, venues, coaches, tournaments, and more.
 
 ## Tech Stack
 - python
@@ -21,13 +21,13 @@ Use TDD by default for new behavior and keep unit/integration/e2e coverage align
 Git Flow with master/develop, feature branches in dedicated worktrees, and Conventional Commits.
 
 ## Domain Context
-Domain context for FFBBApiClientV2_Python; refine with business-specific details.
+French basketball federation data ecosystem. The API serves club management, competition tracking, match scheduling, venue/court geolocation, coach/official registries, 3x3 tournaments, and training/formation catalogs. Data is accessed via dual backends: Directus (relational, FK-based) and Meilisearch (denormalized, full-text + geo-spatial search). Token-based authentication with automatic token management via TokenManager.
 
 ## Important Constraints
 Preserve backward compatibility, enforce quality/security gates, and follow Git Flow/worktree policy.
 
 ## External Dependencies
-External APIs/services and third-party dependencies used by FFBBApiClientV2_Python.
+FFBB Directus REST API (https://api.ffbb.app/), FFBB Meilisearch instance, requests, requests-cache (HTTP caching), python-dateutil, python-dotenv.
 
 <!-- BEGIN:OPENSPEC_DELIVERY_RULES -->
 ## Delivery Rules (Managed)


### PR DESCRIPTION
## Summary
- Add gitleaks pre-commit hook for secret scanning (`security_secret_scanning` → PASS)
- Replace generic placeholder text in `openspec/project.md` with accurate FFBB domain context (`governance_openspec_context_quality` → PASS)

## Validation
- [x] pre-commit passed
- [x] tox tests passed (1753 passed, 96.87% coverage)
- [x] gitleaks passed (no leaks found)
- [ ] CI checks pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)