### PR TITLE
docs(openspec): fix-conversion-mismatch-detection proposal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Store the distribution files for use in other stages
         # `tests` and `publish` will use the same pre-built distributions,
         # so we make sure to release the exact same package that was tested
+        if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v4
         with:
           name: python-distribution-files

--- a/examples/conversion_coverage_check.py
+++ b/examples/conversion_coverage_check.py
@@ -24,13 +24,21 @@ from __future__ import annotations
 
 import argparse
 import logging
+import re
 import sys
 import time
 import traceback
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
-from ffbb_api_client_v2 import FFBBAPIClientV2, TokenManager
+# Ensure local src/ takes precedence over editable installs
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_SRC_DIR = str(_SCRIPT_DIR.parent / "src")
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, _SRC_DIR)
+
+from ffbb_api_client_v2 import FFBBAPIClientV2, TokenManager  # noqa: E402
 
 # Logger targeted by all from_* helpers
 _CONVERTER_LOGGER = "ffbb_api_client_v2.utils.converter_utils"
@@ -67,6 +75,90 @@ class WarningCollector(logging.Handler):
         self._records.clear()
         return msgs
 
+    def drain_grouped(self) -> list[tuple[str, int, list[str]]]:
+        """Return deduplicated warnings as (signature, count, example_values).
+
+        Groups warnings by a normalized signature (function + key + error kind),
+        counts occurrences, and collects distinct concrete values seen.
+        """
+        msgs = [self.format(r) for r in self._records]
+        self._records.clear()
+
+        groups: dict[str, list[str]] = {}
+        for msg in msgs:
+            sig = _warning_signature(msg)
+            groups.setdefault(sig, []).append(msg)
+
+        result: list[tuple[str, int, list[str]]] = []
+        for sig, occurrences in groups.items():
+            distinct_values = _extract_distinct_values(occurrences)
+            result.append((sig, len(occurrences), distinct_values))
+        result.sort(key=lambda x: -x[1])
+        return result
+
+
+# Regex patterns for normalizing warning messages into signatures
+_RE_CANNOT_PARSE = re.compile(r"(from_int\('[^']+'\): cannot parse )'[^']*'( as int)")
+_RE_UNEXPECTED_TYPE = re.compile(
+    r"(from_int\('[^']+'\): unexpected type \w+) \(value: [^)]*\)"
+)
+_RE_FROM_OBJ = re.compile(r"(from_obj\('[^']+'\): expected dict or None, got \w+)")
+_RE_UNKNOWN_ENUM = re.compile(r"(from_enum\([^,]+, '[^']+'\): unknown value )'([^']*)'")
+_RE_FROM_UUID = re.compile(r"(from_uuid\('[^']+'\): invalid UUID) '.{0,80}")
+_RE_FROM_STR = re.compile(r"(from_str\('[^']+'\): cannot convert \w+ to str)")
+_RE_PARSE_VALUE = re.compile(r"cannot parse '([^']*)' as int")
+_RE_ENUM_VALUE = re.compile(r"unknown value '([^']*)'")
+_RE_UUID_VALUE = re.compile(r"invalid UUID '([^']{0,40})")
+
+
+def _warning_signature(msg: str) -> str:
+    """Normalize a warning message into a stable signature for grouping."""
+    m = _RE_CANNOT_PARSE.search(msg)
+    if m:
+        return f"{m.group(1)}<value>{m.group(2)}"
+    m = _RE_UNEXPECTED_TYPE.search(msg)
+    if m:
+        return m.group(1)
+    m = _RE_FROM_OBJ.search(msg)
+    if m:
+        return m.group(1)
+    m = _RE_UNKNOWN_ENUM.search(msg)
+    if m:
+        return f"{m.group(1)}'{m.group(2)}'"
+    m = _RE_FROM_UUID.search(msg)
+    if m:
+        return f"{m.group(1)} <value>"
+    m = _RE_FROM_STR.search(msg)
+    if m:
+        return m.group(1)
+    # Fallback: truncate to prevent huge output from blob values
+    return msg[:120]
+
+
+def _extract_distinct_values(messages: list[str], max_vals: int = 5) -> list[str]:
+    """Extract distinct concrete values from a group of similar warnings."""
+    _value_patterns = [_RE_PARSE_VALUE, _RE_ENUM_VALUE, _RE_UUID_VALUE]
+    values: list[str] = []
+    seen: set[str] = set()
+    for msg in messages:
+        v = None
+        for pat in _value_patterns:
+            m = pat.search(msg)
+            if m:
+                v = m.group(1)
+                break
+        if v is None:
+            continue
+        # Truncate very long values (e.g. base64 blobs)
+        if len(v) > 40:
+            v = v[:40] + "..."
+        if v not in seen:
+            seen.add(v)
+            values.append(v)
+        if len(values) >= max_vals:
+            break
+    return values
+
 
 @dataclass
 class ExceptionRecord:
@@ -84,13 +176,22 @@ class CheckResult:
     """Aggregated result for a single check."""
 
     label: str
-    warnings: list[str] = field(default_factory=list)
+    # Each entry: (signature, count, example_values)
+    warning_groups: list[tuple[str, int, list[str]]] = field(default_factory=list)
     exceptions: list[ExceptionRecord] = field(default_factory=list)
     records_parsed: int = 0
 
     @property
+    def total_warnings(self) -> int:
+        return sum(count for _, count, _ in self.warning_groups)
+
+    @property
+    def distinct_warnings(self) -> int:
+        return len(self.warning_groups)
+
+    @property
     def has_issues(self) -> bool:
-        return bool(self.warnings or self.exceptions)
+        return bool(self.warning_groups or self.exceptions)
 
 
 @dataclass
@@ -102,7 +203,11 @@ class SectionResult:
 
     @property
     def total_warnings(self) -> int:
-        return sum(len(c.warnings) for c in self.checks)
+        return sum(c.total_warnings for c in self.checks)
+
+    @property
+    def distinct_warnings(self) -> int:
+        return sum(c.distinct_warnings for c in self.checks)
 
     @property
     def total_exceptions(self) -> int:
@@ -199,28 +304,37 @@ def _safe_call(
         return None, record
 
 
+_MAX_GROUPS_DISPLAYED = 10
+
+
 def _report_check(check: CheckResult) -> None:
-    """Print check result line."""
+    """Print check result line with deduplicated warnings."""
     parts = []
-    if check.warnings:
-        parts.append(f"{len(check.warnings)} warn")
+    if check.warning_groups:
+        parts.append(
+            f"{check.total_warnings} warn ({check.distinct_warnings} distinct)"
+        )
     if check.exceptions:
         parts.append(f"{len(check.exceptions)} exc")
 
     if parts:
-        status = "WARN"
         detail = ", ".join(parts)
-        print(f"  {status}  {check.label}: {detail}  ({check.records_parsed} records)")
-        for w in check.warnings[:10]:
-            print(f"        [W] {w}")
-        if len(check.warnings) > 10:
-            print(f"        ... and {len(check.warnings) - 10} more warnings")
-        for e in check.exceptions[:10]:
+        print(f"  WARN  {check.label}: {detail}  ({check.records_parsed} records)")
+        for sig, count, examples in check.warning_groups[:_MAX_GROUPS_DISPLAYED]:
+            print(f"        [W] x{count:<5} {sig}")
+            if examples:
+                vals = ", ".join(repr(v) for v in examples[:5])
+                print(f"                   values: [{vals}]")
+        remaining = len(check.warning_groups) - _MAX_GROUPS_DISPLAYED
+        if remaining > 0:
+            print(f"        ... and {remaining} more distinct warning types")
+        for e in check.exceptions[:_MAX_GROUPS_DISPLAYED]:
             print(f"        [E] {e.exception_type}: {e.message}")
             if e.context:
                 print(f"            context: {e.context}")
-        if len(check.exceptions) > 10:
-            print(f"        ... and {len(check.exceptions) - 10} more exceptions")
+        remaining_exc = len(check.exceptions) - _MAX_GROUPS_DISPLAYED
+        if remaining_exc > 0:
+            print(f"        ... and {remaining_exc} more exceptions")
     else:
         print(f"  OK    {check.label}  ({check.records_parsed} records)")
 
@@ -403,7 +517,7 @@ def run_section_a(
                 check.exceptions.append(exc)
             else:
                 check.records_parsed += _count_hits(result)
-        check.warnings = collector.drain()
+        check.warning_groups = collector.drain_grouped()
         _report_check(check)
         section.checks.append(check)
         time.sleep(_RATE_DELAY)
@@ -439,7 +553,7 @@ def run_section_b(
             check.exceptions.append(exc)
         else:
             check.records_parsed = _count_hits(result)
-        check.warnings = collector.drain()
+        check.warning_groups = collector.drain_grouped()
         _report_check(check)
         section.checks.append(check)
         time.sleep(_RATE_DELAY)
@@ -484,7 +598,7 @@ def run_section_c(
             elif result is not None:
                 check.records_parsed += 1
             time.sleep(_RATE_DELAY)
-        check.warnings = collector.drain()
+        check.warning_groups = collector.drain_grouped()
         _report_check(check)
         section.checks.append(check)
 
@@ -543,7 +657,7 @@ def run_section_d(
             check.exceptions.append(exc)
         else:
             check.records_parsed = _count_hits(result)
-        check.warnings = collector.drain()
+        check.warning_groups = collector.drain_grouped()
         _report_check(check)
         section.checks.append(check)
         time.sleep(_RATE_DELAY)
@@ -557,40 +671,44 @@ def run_section_d(
 def _print_summary(sections: list[SectionResult]) -> int:
     """Print final summary table. Returns total issue count."""
     total_warnings = sum(s.total_warnings for s in sections)
+    total_distinct = sum(s.distinct_warnings for s in sections)
     total_exceptions = sum(s.total_exceptions for s in sections)
     total_records = sum(s.total_records for s in sections)
-    total_issues = total_warnings + total_exceptions
+    total_issues = total_distinct + total_exceptions
 
-    print("\n" + "=" * 64)
-    print(f"{'Section':<35} {'Records':>8} {'Warns':>6} {'Excpts':>6}")
-    print("-" * 64)
+    print("\n" + "=" * 72)
+    print(
+        f"{'Section':<35} {'Records':>8} " f"{'Warns':>6} {'Distinct':>8} {'Excpts':>6}"
+    )
+    print("-" * 72)
     for s in sections:
         marker = " *" if s.has_issues else ""
         print(
             f"  {s.name:<33} {s.total_records:>8} "
-            f"{s.total_warnings:>6} {s.total_exceptions:>6}{marker}"
+            f"{s.total_warnings:>6} {s.distinct_warnings:>8} "
+            f"{s.total_exceptions:>6}{marker}"
         )
-    print("-" * 64)
+    print("-" * 72)
     print(
         f"  {'TOTAL':<33} {total_records:>8} "
-        f"{total_warnings:>6} {total_exceptions:>6}"
+        f"{total_warnings:>6} {total_distinct:>8} {total_exceptions:>6}"
     )
-    print("=" * 64)
+    print("=" * 72)
 
     if total_issues == 0:
         print("ALL CHECKS PASSED - no conversion warnings or exceptions detected")
     else:
-        if total_warnings:
+        if total_distinct:
             print(
-                f"WARNINGS: {total_warnings} - "
-                "unhandled enum values or unexpected types in API data."
+                f"WARNINGS: {total_warnings} occurrences across "
+                f"{total_distinct} distinct issue(s)"
             )
         if total_exceptions:
             print(
                 f"EXCEPTIONS: {total_exceptions} - "
                 "runtime errors during model parsing."
             )
-    print("=" * 64)
+    print("=" * 72)
     return total_issues
 
 
@@ -613,7 +731,9 @@ def main() -> None:
     )
 
     collector = WarningCollector()
-    logging.getLogger(_CONVERTER_LOGGER).addHandler(collector)
+    conv_logger = logging.getLogger(_CONVERTER_LOGGER)
+    conv_logger.addHandler(collector)
+    conv_logger.propagate = False  # prevent duplicate output to stderr
 
     run_sections = args.section.upper() if args.section else "ABCD"
     sections: list[SectionResult] = []
@@ -632,7 +752,8 @@ def main() -> None:
     if "D" in run_sections:
         sections.append(run_section_d(client, collector))
 
-    logging.getLogger(_CONVERTER_LOGGER).removeHandler(collector)
+    conv_logger.removeHandler(collector)
+    conv_logger.propagate = True  # restore default
 
     total_issues = _print_summary(sections)
     sys.exit(1 if total_issues > 0 else 0)

--- a/examples/conversion_coverage_check.py
+++ b/examples/conversion_coverage_check.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Conversion Coverage Check - Detect unhandled from_* conversion values.
+
+Fetches thousands of real API records via Meilisearch and Directus,
+captures all WARNING logs from converter_utils during parsing, and
+reports any conversion warning -- surfacing exactly which key/value/enum
+is unhandled.
+
+This script is useful for:
+- Detecting new enum values introduced by the FFBB API
+- Finding unexpected types in API responses
+- Validating that all from_* converters handle real-world data
+
+Usage:
+    python examples/conversion_coverage_check.py
+    python examples/conversion_coverage_check.py --section A   # Meilisearch only
+    python examples/conversion_coverage_check.py --section B   # Directus only
+    python examples/conversion_coverage_check.py --section C   # FK resolution only
+    python examples/conversion_coverage_check.py --section D   # Enum sweeps only
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from typing import Any
+
+from ffbb_api_client_v2 import FFBBAPIClientV2, TokenManager
+
+# Logger targeted by all from_* helpers
+_CONVERTER_LOGGER = "ffbb_api_client_v2.utils.converter_utils"
+
+# Rate-limit delay between API calls (seconds)
+_RATE_DELAY = 0.3
+
+# Meilisearch max per query
+_MLS_LIMIT = 1000
+
+# Directus bulk page ceiling
+_DIR_MAX = 2000
+
+# Max FK IDs to resolve per type
+_FK_BATCH = 10
+
+
+# ---------------------------------------------------------------------------
+# WarningCollector
+# ---------------------------------------------------------------------------
+class WarningCollector(logging.Handler):
+    """Captures WARNING+ log records from converter_utils."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.WARNING)
+        self._records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self._records.append(record)
+
+    def drain(self) -> list[str]:
+        """Return formatted messages and clear buffer."""
+        msgs = [self.format(r) for r in self._records]
+        self._records.clear()
+        return msgs
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _extract_ids(items: list[Any] | None, limit: int = _FK_BATCH) -> list[int]:
+    if not items:
+        return []
+    ids: list[int] = []
+    for item in items:
+        if isinstance(item, int):
+            ids.append(item)
+        elif isinstance(item, dict) and "id" in item:
+            try:
+                ids.append(int(item["id"]))
+            except (ValueError, TypeError):
+                pass
+        else:
+            item_id = getattr(item, "id", None)
+            if item_id is not None:
+                try:
+                    ids.append(int(item_id))
+                except (ValueError, TypeError):
+                    pass
+        if len(ids) >= limit:
+            break
+    return ids
+
+
+def _extract_str_ids(items: list[Any] | None, limit: int = _FK_BATCH) -> list[str]:
+    if not items:
+        return []
+    ids: list[str] = []
+    for item in items:
+        if isinstance(item, str):
+            ids.append(item)
+        elif isinstance(item, dict) and "id" in item:
+            ids.append(str(item["id"]))
+        else:
+            item_id = getattr(item, "id", None)
+            if item_id is not None:
+                ids.append(str(item_id))
+        if len(ids) >= limit:
+            break
+    return ids
+
+
+def _report(label: str, warnings: list[str]) -> bool:
+    """Print check result. Returns True if warnings found."""
+    if warnings:
+        print(f"  WARN  {label}: {len(warnings)} warning(s)")
+        for w in warnings[:20]:
+            print(f"         - {w}")
+        if len(warnings) > 20:
+            print(f"         ... and {len(warnings) - 20} more")
+        return True
+    print(f"  OK    {label}")
+    return False
+
+
+# ---------------------------------------------------------------------------
+# ID Discovery
+# ---------------------------------------------------------------------------
+def discover_ids(
+    client: FFBBAPIClientV2, collector: WarningCollector
+) -> dict[str, list]:
+    """Chain through live data to collect IDs for FK resolution."""
+    print("\n--- Discovering IDs for FK resolution ---")
+    ids: dict[str, list] = {
+        "organismes": [],
+        "salles": [],
+        "engagements": [],
+        "competitions": [],
+        "poules": [],
+        "rencontres": [],
+        "terrains": [],
+        "tournois": [],
+        "formations": [],
+    }
+
+    # 1) Search organismes
+    org_result = client.search_organismes(None, limit=_MLS_LIMIT)
+    if org_result and org_result.hits:
+        for hit in org_result.hits[:_FK_BATCH]:
+            if hit.id is not None:
+                try:
+                    ids["organismes"].append(int(hit.id))
+                except (ValueError, TypeError):
+                    pass
+
+    # 2) Get organisme details -> salle + engagement IDs
+    for org_id in ids["organismes"][:5]:
+        time.sleep(_RATE_DELAY)
+        org = client.get_organisme(org_id)
+        if org is not None:
+            if isinstance(org.salle, int):
+                ids["salles"].append(org.salle)
+            remaining = _FK_BATCH - len(ids["engagements"])
+            if remaining > 0:
+                ids["engagements"].extend(_extract_ids(org.engagements, remaining))
+            remaining = _FK_BATCH - len(ids["competitions"])
+            if remaining > 0:
+                ids["competitions"].extend(_extract_ids(org.competitions, remaining))
+
+    # 3) Engagement details -> competition + poule IDs
+    for eng_id in ids["engagements"][:5]:
+        time.sleep(_RATE_DELAY)
+        eng = client.get_engagement(eng_id)
+        if eng is not None:
+            if isinstance(eng.idCompetition, int):
+                if eng.idCompetition not in ids["competitions"]:
+                    ids["competitions"].append(eng.idCompetition)
+            if isinstance(eng.idPoule, int):
+                ids["poules"].append(eng.idPoule)
+
+    # 4) Poule details -> rencontre IDs
+    for poule_id in ids["poules"][:3]:
+        time.sleep(_RATE_DELAY)
+        poule = client.get_poule(poule_id)
+        if poule is not None:
+            remaining = _FK_BATCH - len(ids["rencontres"])
+            if remaining > 0:
+                ids["rencontres"].extend(_extract_ids(poule.rencontres, remaining))
+
+    # 5-7) Search for terrains, tournois, formations
+    for key, search_fn in [
+        ("terrains", client.search_terrains),
+        ("tournois", client.search_tournois),
+    ]:
+        time.sleep(_RATE_DELAY)
+        result = search_fn(None, limit=100)
+        if result and result.hits:
+            for hit in result.hits[:_FK_BATCH]:
+                if hit.id is not None:
+                    try:
+                        ids[key].append(int(hit.id))
+                    except (ValueError, TypeError):
+                        pass
+
+    time.sleep(_RATE_DELAY)
+    form_result = client.search_formations(None, limit=100)
+    if form_result and form_result.hits:
+        ids["formations"] = _extract_str_ids(form_result.hits, _FK_BATCH)
+
+    # Drain discovery warnings (not part of checks)
+    collector.drain()
+
+    for key, vals in ids.items():
+        print(f"  {key}: {len(vals)} IDs")
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# Section runners
+# ---------------------------------------------------------------------------
+def run_section_a(client: FFBBAPIClientV2, collector: WarningCollector) -> int:
+    """Section A: Meilisearch bulk search coverage."""
+    print("\n=== Section A: Meilisearch Bulk Search ===")
+    total_warns = 0
+
+    checks: list[tuple[str, Any, list[str | None]]] = [
+        (
+            "search_organismes",
+            client.search_organismes,
+            [None, "Paris", "Lyon", "Marseille"],
+        ),
+        (
+            "search_competitions",
+            client.search_competitions,
+            [None, "Championnat", "Coupe", "3x3", "Plateau"],
+        ),
+        (
+            "search_rencontres",
+            client.search_rencontres,
+            [None, "Paris", "3x3", "Handisport"],
+        ),
+        ("search_salles", client.search_salles, [None, "Paris", "Lyon"]),
+        ("search_terrains", client.search_terrains, [None, "Paris", "Lyon"]),
+        (
+            "search_tournois",
+            client.search_tournois,
+            [None, "3x3", "Féminin", "Masculin"],
+        ),
+        (
+            "search_pratiques",
+            client.search_pratiques,
+            [None, "basket", "santé", "inclusif"],
+        ),
+        ("search_engagements", client.search_engagements, [None, "Paris", "Pro"]),
+        ("search_formations", client.search_formations, [None, "arbitrage"]),
+    ]
+
+    for label, search_fn, queries in checks:
+        collector.drain()
+        for q in queries:
+            search_fn(q, limit=_MLS_LIMIT)
+        warnings = collector.drain()
+        if _report(label, warnings):
+            total_warns += len(warnings)
+        time.sleep(_RATE_DELAY)
+
+    return total_warns
+
+
+def run_section_b(client: FFBBAPIClientV2, collector: WarningCollector) -> int:
+    """Section B: Directus bulk list coverage."""
+    print("\n=== Section B: Directus Bulk List ===")
+    total_warns = 0
+
+    checks: list[tuple[str, Any, dict]] = [
+        ("get_saisons", client.get_saisons, {"filter_criteria": None}),
+        ("list_all_rencontres", client.list_all_rencontres, {"max_items": _DIR_MAX}),
+        ("list_all_salles", client.list_all_salles, {"max_items": _DIR_MAX}),
+        ("list_all_terrains", client.list_all_terrains, {"max_items": _DIR_MAX}),
+        ("list_all_tournois", client.list_all_tournois, {"max_items": _DIR_MAX}),
+        ("list_all_engagements", client.list_all_engagements, {"max_items": _DIR_MAX}),
+        ("list_all_formations", client.list_all_formations, {"max_items": _DIR_MAX}),
+        ("list_all_pratiques", client.list_all_pratiques, {"max_items": _DIR_MAX}),
+        ("list_all_communes", client.list_all_communes, {"max_items": _DIR_MAX}),
+        ("get_lives", client.get_lives, {}),
+    ]
+
+    for label, list_fn, kwargs in checks:
+        collector.drain()
+        list_fn(**kwargs)
+        warnings = collector.drain()
+        if _report(label, warnings):
+            total_warns += len(warnings)
+        time.sleep(_RATE_DELAY)
+
+    return total_warns
+
+
+def run_section_c(
+    client: FFBBAPIClientV2,
+    collector: WarningCollector,
+    ids: dict[str, list],
+) -> int:
+    """Section C: FK resolution chain."""
+    print("\n=== Section C: FK Resolution Chain ===")
+    total_warns = 0
+
+    fk_checks: list[tuple[str, str, Any]] = [
+        ("get_organisme", "organismes", client.get_organisme),
+        ("get_competition", "competitions", client.get_competition),
+        ("get_poule", "poules", client.get_poule),
+        ("get_engagement", "engagements", client.get_engagement),
+        ("get_rencontre", "rencontres", client.get_rencontre),
+        ("get_salle", "salles", client.get_salle),
+        ("get_terrain", "terrains", client.get_terrain),
+        ("get_tournoi", "tournois", client.get_tournoi),
+        ("get_formation", "formations", client.get_formation),
+    ]
+
+    for label, id_key, get_fn in fk_checks:
+        id_list = ids.get(id_key, [])
+        if not id_list:
+            print(f"  SKIP  {label}: no IDs discovered")
+            continue
+        collector.drain()
+        for item_id in id_list[:_FK_BATCH]:
+            get_fn(item_id)
+            time.sleep(_RATE_DELAY)
+        warnings = collector.drain()
+        if _report(label, warnings):
+            total_warns += len(warnings)
+
+    return total_warns
+
+
+def run_section_d(client: FFBBAPIClientV2, collector: WarningCollector) -> int:
+    """Section D: High-diversity enum sweeps."""
+    print("\n=== Section D: High-Diversity Enum Sweeps ===")
+    total_warns = 0
+
+    sweeps: list[tuple[str, Any, list[str | None]]] = [
+        (
+            "sweep_competitions",
+            client.search_multiple_competitions,
+            [None, "Championnat", "Coupe", "3x3", "Féminin", "Mixte"],
+        ),
+        (
+            "sweep_rencontres",
+            client.search_multiple_rencontres,
+            [None, "Départemental", "Régional", "National", "3x3"],
+        ),
+        (
+            "sweep_tournois",
+            client.search_multiple_tournois,
+            [None, "3x3", "5x5", "Féminin", "Masculin"],
+        ),
+        (
+            "sweep_terrains",
+            client.search_multiple_terrains,
+            [None, "Paris", "Lyon", "Marseille"],
+        ),
+        (
+            "sweep_pratiques",
+            client.search_multiple_pratiques,
+            [None, "basket", "santé", "inclusif", "tonik"],
+        ),
+    ]
+
+    for label, search_fn, queries in sweeps:
+        collector.drain()
+        search_fn(queries, limit=_MLS_LIMIT)
+        warnings = collector.drain()
+        if _report(label, warnings):
+            total_warns += len(warnings)
+        time.sleep(_RATE_DELAY)
+
+    return total_warns
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Conversion coverage check")
+    parser.add_argument(
+        "--section",
+        choices=["A", "B", "C", "D"],
+        help="Run only one section (A=Meilisearch, B=Directus, C=FK, D=Sweeps)",
+    )
+    args = parser.parse_args()
+
+    tokens = TokenManager.get_tokens()
+    client = FFBBAPIClientV2.create(
+        api_bearer_token=tokens.api_token,
+        meilisearch_bearer_token=tokens.meilisearch_token,
+    )
+
+    collector = WarningCollector()
+    logging.getLogger(_CONVERTER_LOGGER).addHandler(collector)
+
+    sections = args.section.upper() if args.section else "ABCD"
+    total_warns = 0
+
+    # Discover IDs if FK resolution needed
+    ids: dict[str, list] = {}
+    if "C" in sections:
+        ids = discover_ids(client, collector)
+
+    if "A" in sections:
+        total_warns += run_section_a(client, collector)
+    if "B" in sections:
+        total_warns += run_section_b(client, collector)
+    if "C" in sections:
+        total_warns += run_section_c(client, collector, ids)
+    if "D" in sections:
+        total_warns += run_section_d(client, collector)
+
+    logging.getLogger(_CONVERTER_LOGGER).removeHandler(collector)
+
+    # Summary
+    print("\n" + "=" * 60)
+    if total_warns == 0:
+        print("ALL CHECKS PASSED - no conversion warnings detected")
+    else:
+        print(f"WARNINGS DETECTED: {total_warns} total conversion warning(s)")
+        print("These indicate unhandled enum values or unexpected types in API data.")
+    print("=" * 60)
+
+    sys.exit(1 if total_warns > 0 else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/conversion_coverage_check.py
+++ b/examples/conversion_coverage_check.py
@@ -3,13 +3,14 @@
 
 Fetches thousands of real API records via Meilisearch and Directus,
 captures all WARNING logs from converter_utils during parsing, and
-reports any conversion warning -- surfacing exactly which key/value/enum
-is unhandled.
+reports any conversion warning or exception -- surfacing exactly which
+key/value/enum is unhandled or which call raised an error.
 
 This script is useful for:
 - Detecting new enum values introduced by the FFBB API
 - Finding unexpected types in API responses
 - Validating that all from_* converters handle real-world data
+- Catching runtime exceptions during model parsing
 
 Usage:
     python examples/conversion_coverage_check.py
@@ -25,6 +26,8 @@ import argparse
 import logging
 import sys
 import time
+import traceback
+from dataclasses import dataclass, field
 from typing import Any
 
 from ffbb_api_client_v2 import FFBBAPIClientV2, TokenManager
@@ -46,7 +49,7 @@ _FK_BATCH = 10
 
 
 # ---------------------------------------------------------------------------
-# WarningCollector
+# Data collectors
 # ---------------------------------------------------------------------------
 class WarningCollector(logging.Handler):
     """Captures WARNING+ log records from converter_utils."""
@@ -63,6 +66,55 @@ class WarningCollector(logging.Handler):
         msgs = [self.format(r) for r in self._records]
         self._records.clear()
         return msgs
+
+
+@dataclass
+class ExceptionRecord:
+    """Stores a caught exception with context."""
+
+    label: str
+    exception_type: str
+    message: str
+    traceback_short: str
+    context: str = ""
+
+
+@dataclass
+class CheckResult:
+    """Aggregated result for a single check."""
+
+    label: str
+    warnings: list[str] = field(default_factory=list)
+    exceptions: list[ExceptionRecord] = field(default_factory=list)
+    records_parsed: int = 0
+
+    @property
+    def has_issues(self) -> bool:
+        return bool(self.warnings or self.exceptions)
+
+
+@dataclass
+class SectionResult:
+    """Aggregated results for a whole section."""
+
+    name: str
+    checks: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def total_warnings(self) -> int:
+        return sum(len(c.warnings) for c in self.checks)
+
+    @property
+    def total_exceptions(self) -> int:
+        return sum(len(c.exceptions) for c in self.checks)
+
+    @property
+    def total_records(self) -> int:
+        return sum(c.records_parsed for c in self.checks)
+
+    @property
+    def has_issues(self) -> bool:
+        return any(c.has_issues for c in self.checks)
 
 
 # ---------------------------------------------------------------------------
@@ -110,17 +162,67 @@ def _extract_str_ids(items: list[Any] | None, limit: int = _FK_BATCH) -> list[st
     return ids
 
 
-def _report(label: str, warnings: list[str]) -> bool:
-    """Print check result. Returns True if warnings found."""
-    if warnings:
-        print(f"  WARN  {label}: {len(warnings)} warning(s)")
-        for w in warnings[:20]:
-            print(f"         - {w}")
-        if len(warnings) > 20:
-            print(f"         ... and {len(warnings) - 20} more")
-        return True
-    print(f"  OK    {label}")
-    return False
+def _count_hits(result: Any) -> int:
+    """Count the number of hits/items in a search or list result."""
+    if result is None:
+        return 0
+    if hasattr(result, "hits") and result.hits:
+        return len(result.hits)
+    if isinstance(result, list):
+        return len(result)
+    return 1
+
+
+def _safe_call(
+    fn: Any,
+    args: tuple = (),
+    kwargs: dict | None = None,
+    label: str = "",
+    context: str = "",
+) -> tuple[Any, ExceptionRecord | None]:
+    """Call fn(*args, **kwargs), returning (result, exception_record | None)."""
+    if kwargs is None:
+        kwargs = {}
+    try:
+        result = fn(*args, **kwargs)
+        return result, None
+    except Exception as exc:
+        tb = traceback.format_exception(type(exc), exc, exc.__traceback__)
+        short_tb = "".join(tb[-3:]) if len(tb) > 3 else "".join(tb)
+        record = ExceptionRecord(
+            label=label,
+            exception_type=type(exc).__name__,
+            message=str(exc)[:200],
+            traceback_short=short_tb.strip(),
+            context=context,
+        )
+        return None, record
+
+
+def _report_check(check: CheckResult) -> None:
+    """Print check result line."""
+    parts = []
+    if check.warnings:
+        parts.append(f"{len(check.warnings)} warn")
+    if check.exceptions:
+        parts.append(f"{len(check.exceptions)} exc")
+
+    if parts:
+        status = "WARN"
+        detail = ", ".join(parts)
+        print(f"  {status}  {check.label}: {detail}  ({check.records_parsed} records)")
+        for w in check.warnings[:10]:
+            print(f"        [W] {w}")
+        if len(check.warnings) > 10:
+            print(f"        ... and {len(check.warnings) - 10} more warnings")
+        for e in check.exceptions[:10]:
+            print(f"        [E] {e.exception_type}: {e.message}")
+            if e.context:
+                print(f"            context: {e.context}")
+        if len(check.exceptions) > 10:
+            print(f"        ... and {len(check.exceptions) - 10} more exceptions")
+    else:
+        print(f"  OK    {check.label}  ({check.records_parsed} records)")
 
 
 # ---------------------------------------------------------------------------
@@ -144,7 +246,9 @@ def discover_ids(
     }
 
     # 1) Search organismes
-    org_result = client.search_organismes(None, limit=_MLS_LIMIT)
+    org_result, _ = _safe_call(
+        client.search_organismes, (None,), {"limit": _MLS_LIMIT}, "discover_orgs"
+    )
     if org_result and org_result.hits:
         for hit in org_result.hits[:_FK_BATCH]:
             if hit.id is not None:
@@ -156,7 +260,9 @@ def discover_ids(
     # 2) Get organisme details -> salle + engagement IDs
     for org_id in ids["organismes"][:5]:
         time.sleep(_RATE_DELAY)
-        org = client.get_organisme(org_id)
+        org, _ = _safe_call(
+            client.get_organisme, (org_id,), label="discover_org_detail"
+        )
         if org is not None:
             if isinstance(org.salle, int):
                 ids["salles"].append(org.salle)
@@ -170,7 +276,7 @@ def discover_ids(
     # 3) Engagement details -> competition + poule IDs
     for eng_id in ids["engagements"][:5]:
         time.sleep(_RATE_DELAY)
-        eng = client.get_engagement(eng_id)
+        eng, _ = _safe_call(client.get_engagement, (eng_id,), label="discover_eng")
         if eng is not None:
             if isinstance(eng.idCompetition, int):
                 if eng.idCompetition not in ids["competitions"]:
@@ -181,19 +287,19 @@ def discover_ids(
     # 4) Poule details -> rencontre IDs
     for poule_id in ids["poules"][:3]:
         time.sleep(_RATE_DELAY)
-        poule = client.get_poule(poule_id)
+        poule, _ = _safe_call(client.get_poule, (poule_id,), label="discover_poule")
         if poule is not None:
             remaining = _FK_BATCH - len(ids["rencontres"])
             if remaining > 0:
                 ids["rencontres"].extend(_extract_ids(poule.rencontres, remaining))
 
-    # 5-7) Search for terrains, tournois, formations
+    # 5-6) Search for terrains, tournois
     for key, search_fn in [
         ("terrains", client.search_terrains),
         ("tournois", client.search_tournois),
     ]:
         time.sleep(_RATE_DELAY)
-        result = search_fn(None, limit=100)
+        result, _ = _safe_call(search_fn, (None,), {"limit": 100}, f"discover_{key}")
         if result and result.hits:
             for hit in result.hits[:_FK_BATCH]:
                 if hit.id is not None:
@@ -202,8 +308,11 @@ def discover_ids(
                     except (ValueError, TypeError):
                         pass
 
+    # 7) Search formations
     time.sleep(_RATE_DELAY)
-    form_result = client.search_formations(None, limit=100)
+    form_result, _ = _safe_call(
+        client.search_formations, (None,), {"limit": 100}, "discover_formations"
+    )
     if form_result and form_result.hits:
         ids["formations"] = _extract_str_ids(form_result.hits, _FK_BATCH)
 
@@ -218,59 +327,96 @@ def discover_ids(
 # ---------------------------------------------------------------------------
 # Section runners
 # ---------------------------------------------------------------------------
-def run_section_a(client: FFBBAPIClientV2, collector: WarningCollector) -> int:
+def run_section_a(
+    client: FFBBAPIClientV2, collector: WarningCollector
+) -> SectionResult:
     """Section A: Meilisearch bulk search coverage."""
     print("\n=== Section A: Meilisearch Bulk Search ===")
-    total_warns = 0
+    section = SectionResult(name="A: Meilisearch Bulk Search")
 
     checks: list[tuple[str, Any, list[str | None]]] = [
         (
             "search_organismes",
             client.search_organismes,
-            [None, "Paris", "Lyon", "Marseille"],
+            [None, "Paris", "Lyon", "Marseille", "Toulouse", "Bordeaux"],
         ),
         (
             "search_competitions",
             client.search_competitions,
-            [None, "Championnat", "Coupe", "3x3", "Plateau"],
+            [
+                None,
+                "Championnat",
+                "Coupe",
+                "3x3",
+                "Plateau",
+                "Pré-National",
+                "Régional",
+                "Départemental",
+                "Entente",
+            ],
         ),
         (
             "search_rencontres",
             client.search_rencontres,
-            [None, "Paris", "3x3", "Handisport"],
+            [None, "Paris", "3x3", "Handisport", "Entente", "Forfait"],
         ),
-        ("search_salles", client.search_salles, [None, "Paris", "Lyon"]),
-        ("search_terrains", client.search_terrains, [None, "Paris", "Lyon"]),
+        (
+            "search_salles",
+            client.search_salles,
+            [None, "Paris", "Lyon", "Gymnase", "Complexe"],
+        ),
+        (
+            "search_terrains",
+            client.search_terrains,
+            [None, "Paris", "Lyon", "Extérieur", "Indoor"],
+        ),
         (
             "search_tournois",
             client.search_tournois,
-            [None, "3x3", "Féminin", "Masculin"],
+            [None, "3x3", "Féminin", "Masculin", "Mixte", "Jeunes"],
         ),
         (
             "search_pratiques",
             client.search_pratiques,
-            [None, "basket", "santé", "inclusif"],
+            [None, "basket", "santé", "inclusif", "micro", "découverte", "tonik"],
         ),
-        ("search_engagements", client.search_engagements, [None, "Paris", "Pro"]),
-        ("search_formations", client.search_formations, [None, "arbitrage"]),
+        (
+            "search_engagements",
+            client.search_engagements,
+            [None, "Paris", "Pro", "Entente", "National", "Féminin"],
+        ),
+        (
+            "search_formations",
+            client.search_formations,
+            [None, "arbitrage", "officiels", "entraîneur"],
+        ),
     ]
 
     for label, search_fn, queries in checks:
+        check = CheckResult(label=label)
         collector.drain()
         for q in queries:
-            search_fn(q, limit=_MLS_LIMIT)
-        warnings = collector.drain()
-        if _report(label, warnings):
-            total_warns += len(warnings)
+            result, exc = _safe_call(
+                search_fn, (q,), {"limit": _MLS_LIMIT}, label, f"query={q!r}"
+            )
+            if exc:
+                check.exceptions.append(exc)
+            else:
+                check.records_parsed += _count_hits(result)
+        check.warnings = collector.drain()
+        _report_check(check)
+        section.checks.append(check)
         time.sleep(_RATE_DELAY)
 
-    return total_warns
+    return section
 
 
-def run_section_b(client: FFBBAPIClientV2, collector: WarningCollector) -> int:
+def run_section_b(
+    client: FFBBAPIClientV2, collector: WarningCollector
+) -> SectionResult:
     """Section B: Directus bulk list coverage."""
     print("\n=== Section B: Directus Bulk List ===")
-    total_warns = 0
+    section = SectionResult(name="B: Directus Bulk List")
 
     checks: list[tuple[str, Any, dict]] = [
         ("get_saisons", client.get_saisons, {"filter_criteria": None}),
@@ -286,24 +432,29 @@ def run_section_b(client: FFBBAPIClientV2, collector: WarningCollector) -> int:
     ]
 
     for label, list_fn, kwargs in checks:
+        check = CheckResult(label=label)
         collector.drain()
-        list_fn(**kwargs)
-        warnings = collector.drain()
-        if _report(label, warnings):
-            total_warns += len(warnings)
+        result, exc = _safe_call(list_fn, kwargs=kwargs, label=label)
+        if exc:
+            check.exceptions.append(exc)
+        else:
+            check.records_parsed = _count_hits(result)
+        check.warnings = collector.drain()
+        _report_check(check)
+        section.checks.append(check)
         time.sleep(_RATE_DELAY)
 
-    return total_warns
+    return section
 
 
 def run_section_c(
     client: FFBBAPIClientV2,
     collector: WarningCollector,
     ids: dict[str, list],
-) -> int:
+) -> SectionResult:
     """Section C: FK resolution chain."""
     print("\n=== Section C: FK Resolution Chain ===")
-    total_warns = 0
+    section = SectionResult(name="C: FK Resolution Chain")
 
     fk_checks: list[tuple[str, str, Any]] = [
         ("get_organisme", "organismes", client.get_organisme),
@@ -322,59 +473,125 @@ def run_section_c(
         if not id_list:
             print(f"  SKIP  {label}: no IDs discovered")
             continue
+        check = CheckResult(label=label)
         collector.drain()
         for item_id in id_list[:_FK_BATCH]:
-            get_fn(item_id)
+            result, exc = _safe_call(
+                get_fn, (item_id,), label=label, context=f"id={item_id!r}"
+            )
+            if exc:
+                check.exceptions.append(exc)
+            elif result is not None:
+                check.records_parsed += 1
             time.sleep(_RATE_DELAY)
-        warnings = collector.drain()
-        if _report(label, warnings):
-            total_warns += len(warnings)
+        check.warnings = collector.drain()
+        _report_check(check)
+        section.checks.append(check)
 
-    return total_warns
+    return section
 
 
-def run_section_d(client: FFBBAPIClientV2, collector: WarningCollector) -> int:
+def run_section_d(
+    client: FFBBAPIClientV2, collector: WarningCollector
+) -> SectionResult:
     """Section D: High-diversity enum sweeps."""
     print("\n=== Section D: High-Diversity Enum Sweeps ===")
-    total_warns = 0
+    section = SectionResult(name="D: High-Diversity Enum Sweeps")
 
     sweeps: list[tuple[str, Any, list[str | None]]] = [
         (
             "sweep_competitions",
             client.search_multiple_competitions,
-            [None, "Championnat", "Coupe", "3x3", "Féminin", "Mixte"],
+            [
+                None,
+                "Championnat",
+                "Coupe",
+                "3x3",
+                "Féminin",
+                "Mixte",
+                "Pré-National",
+                "Départemental",
+            ],
         ),
         (
             "sweep_rencontres",
             client.search_multiple_rencontres,
-            [None, "Départemental", "Régional", "National", "3x3"],
+            [None, "Départemental", "Régional", "National", "3x3", "Entente"],
         ),
         (
             "sweep_tournois",
             client.search_multiple_tournois,
-            [None, "3x3", "5x5", "Féminin", "Masculin"],
+            [None, "3x3", "5x5", "Féminin", "Masculin", "Mixte", "Jeunes"],
         ),
         (
             "sweep_terrains",
             client.search_multiple_terrains,
-            [None, "Paris", "Lyon", "Marseille"],
+            [None, "Paris", "Lyon", "Marseille", "Extérieur"],
         ),
         (
             "sweep_pratiques",
             client.search_multiple_pratiques,
-            [None, "basket", "santé", "inclusif", "tonik"],
+            [None, "basket", "santé", "inclusif", "tonik", "micro", "découverte"],
         ),
     ]
 
     for label, search_fn, queries in sweeps:
+        check = CheckResult(label=label)
         collector.drain()
-        search_fn(queries, limit=_MLS_LIMIT)
-        warnings = collector.drain()
-        if _report(label, warnings):
-            total_warns += len(warnings)
+        result, exc = _safe_call(search_fn, (queries,), {"limit": _MLS_LIMIT}, label)
+        if exc:
+            check.exceptions.append(exc)
+        else:
+            check.records_parsed = _count_hits(result)
+        check.warnings = collector.drain()
+        _report_check(check)
+        section.checks.append(check)
         time.sleep(_RATE_DELAY)
 
-    return total_warns
+    return section
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+def _print_summary(sections: list[SectionResult]) -> int:
+    """Print final summary table. Returns total issue count."""
+    total_warnings = sum(s.total_warnings for s in sections)
+    total_exceptions = sum(s.total_exceptions for s in sections)
+    total_records = sum(s.total_records for s in sections)
+    total_issues = total_warnings + total_exceptions
+
+    print("\n" + "=" * 64)
+    print(f"{'Section':<35} {'Records':>8} {'Warns':>6} {'Excpts':>6}")
+    print("-" * 64)
+    for s in sections:
+        marker = " *" if s.has_issues else ""
+        print(
+            f"  {s.name:<33} {s.total_records:>8} "
+            f"{s.total_warnings:>6} {s.total_exceptions:>6}{marker}"
+        )
+    print("-" * 64)
+    print(
+        f"  {'TOTAL':<33} {total_records:>8} "
+        f"{total_warnings:>6} {total_exceptions:>6}"
+    )
+    print("=" * 64)
+
+    if total_issues == 0:
+        print("ALL CHECKS PASSED - no conversion warnings or exceptions detected")
+    else:
+        if total_warnings:
+            print(
+                f"WARNINGS: {total_warnings} - "
+                "unhandled enum values or unexpected types in API data."
+            )
+        if total_exceptions:
+            print(
+                f"EXCEPTIONS: {total_exceptions} - "
+                "runtime errors during model parsing."
+            )
+    print("=" * 64)
+    return total_issues
 
 
 # ---------------------------------------------------------------------------
@@ -398,35 +615,27 @@ def main() -> None:
     collector = WarningCollector()
     logging.getLogger(_CONVERTER_LOGGER).addHandler(collector)
 
-    sections = args.section.upper() if args.section else "ABCD"
-    total_warns = 0
+    run_sections = args.section.upper() if args.section else "ABCD"
+    sections: list[SectionResult] = []
 
     # Discover IDs if FK resolution needed
     ids: dict[str, list] = {}
-    if "C" in sections:
+    if "C" in run_sections:
         ids = discover_ids(client, collector)
 
-    if "A" in sections:
-        total_warns += run_section_a(client, collector)
-    if "B" in sections:
-        total_warns += run_section_b(client, collector)
-    if "C" in sections:
-        total_warns += run_section_c(client, collector, ids)
-    if "D" in sections:
-        total_warns += run_section_d(client, collector)
+    if "A" in run_sections:
+        sections.append(run_section_a(client, collector))
+    if "B" in run_sections:
+        sections.append(run_section_b(client, collector))
+    if "C" in run_sections:
+        sections.append(run_section_c(client, collector, ids))
+    if "D" in run_sections:
+        sections.append(run_section_d(client, collector))
 
     logging.getLogger(_CONVERTER_LOGGER).removeHandler(collector)
 
-    # Summary
-    print("\n" + "=" * 60)
-    if total_warns == 0:
-        print("ALL CHECKS PASSED - no conversion warnings detected")
-    else:
-        print(f"WARNINGS DETECTED: {total_warns} total conversion warning(s)")
-        print("These indicate unhandled enum values or unexpected types in API data.")
-    print("=" * 60)
-
-    sys.exit(1 if total_warns > 0 else 0)
+    total_issues = _print_summary(sections)
+    sys.exit(1 if total_issues > 0 else 0)
 
 
 if __name__ == "__main__":

--- a/openspec/changes/fix-conversion-mismatch-detection/.openspec.yaml
+++ b/openspec/changes/fix-conversion-mismatch-detection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-04

--- a/openspec/changes/fix-conversion-mismatch-detection/design.md
+++ b/openspec/changes/fix-conversion-mismatch-detection/design.md
@@ -1,0 +1,85 @@
+## Context
+
+The FFBB API client library (`ffbb_api_client_v2`) wraps two APIs — Directus REST and MeiliSearch — into Python dataclass models with typed converters (`from_dict`/`to_dict`). Over time, model definitions drifted from actual API responses: FK fields typed as objects receive scalar IDs, enum values are incomplete, duplicate models exist for the same JSON structures, and naming is inconsistent.
+
+The `discover_types.py` script (recently fixed to use library-defined fields with sampling) produced a comprehensive mismatch report that drives this change.
+
+**Current state:**
+- 52 dataclasses, 32 enums, 2 str subclasses in `models/`
+- 9 Hit models, 7 FacetDistribution models in `meilisearch_ffbb/models/`
+- 15 Response + 12 Fields models in `directus_ffbb/models/`
+- ~10 duplicate model pairs (subsets of each other)
+- Inconsistent suffixes: `*ID`, `*Class`, `*Ref` with no clear convention
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate all confirmed type mismatches (Tier 1 FK scalars, Tier 2 enum gaps, Tier 3 value types)
+- Remove duplicate models by merging subsets into supersets
+- Establish consistent naming: `*Enum` for enums, `*Facet` for facet counts, no arbitrary suffixes
+- Ensure PascalCase class names match snake_case module names
+- Deduplicate cross-API enums (single source of truth in `models/`)
+- Update all consumers (tests, scripts, examples)
+
+**Non-Goals:**
+- Refactoring the converter utility functions (`from_obj`, `from_str`, etc.)
+- Adding new API endpoints or capabilities
+- Changing the MeiliSearch Hit model architecture (expanded objects are correct there)
+- Modifying FacetDistribution dataclass patterns (confirmed correct)
+- Full backward compatibility — this is a breaking major version change
+
+## Decisions
+
+### D1: Phased execution order (enum rename -> dedup -> model rename -> type fixes)
+
+**Decision**: Execute renames before type fixes to avoid dealing with stale class names during converter changes.
+
+**Rationale**: Renaming enums first (Phase 0) frees base names. Deduplication (Phase 1) reduces the number of models to fix. Model renames (Phase 3) establish final names. Only then do type fixes (Phase 4-5) apply to the final model structure.
+
+**Alternative considered**: Fix types first, rename later. Rejected because it would require fixing types on models that get deleted during dedup, wasting effort.
+
+### D2: Merge subsets into supersets (not the reverse)
+
+**Decision**: When two models overlap, keep the one with more fields and delete the smaller one. Extra fields will simply be `None` when not populated.
+
+**Rationale**: The superset model is always correct (extra fields default to `None`). The subset model loses data when used in contexts that provide more fields.
+
+**Examples**: `PurpleLogo` (1 field) -> `Logo` (2 fields), `TeamEngagement` (4 fields) -> `EngagementEquipe` (6 fields).
+
+### D3: CompetitionBase inheritance for Competition variants
+
+**Decision**: Create `CompetitionBase` with 10 shared fields, `Competition` (ex-CompetitionID, +5 fields) and `CompetitionDetail` (ex-CompetitionRef, +4 fields) inheriting from it.
+
+**Rationale**: The two models share 10 JSON keys but have different extra fields and are used in different API contexts. A base class avoids code duplication while preserving distinct types.
+
+**Alternative considered**: Single `Competition` model with all 19 fields. Rejected because the two contexts never provide all fields simultaneously — a unified model would mislead consumers.
+
+### D4: Keep `categorie` and `type_competition_generique` as model types in Competition
+
+**Decision**: Keep `Categorie | None` and `TypeCompetitionGenerique | None` (not `str | None`).
+
+**Rationale**: `competition_fields.py` uses dot-notation (`categorie.id`, `categorie.code`...), so Directus always returns expanded dicts. The Tier 1 mismatches for these fields come from Wave 3 FK chain sampling (different context). A validation script will confirm.
+
+### D5: One commit per phase
+
+**Decision**: Each phase produces a separate conventional commit.
+
+**Rationale**: Keeps changes reviewable and revertable. If a phase introduces issues, it can be reverted independently.
+
+### D6: Module naming follows class naming
+
+**Decision**: Every renamed class gets a renamed module file matching `snake_case(ClassName)`.
+
+**Rationale**: Convention enforcement — `SexeEnum` lives in `sexe_enum.py`, `SexeFacet` in `sexe_facet.py`. Makes imports predictable.
+
+## Risks / Trade-offs
+
+**[Risk] Mass rename breaks downstream consumers** -> This is a library; any consumer importing model classes will break. Mitigation: major version bump, complete changelog documenting every rename.
+
+**[Risk] Enum dedup across APIs may miss subtle value differences** -> `SexeEnum` in models/ uses `MIXED` while meilisearch uses `MIXTE` for the same value `"Mixte"`. Mitigation: standardize on `MIXTE` (matches the French string value).
+
+**[Risk] Competition base class inheritance may affect dataclass behavior** -> Mitigation: these models use `@dataclass` with `from_dict`/`to_dict`. The inheritance is straightforward with no metaclass conflicts.
+
+**[Risk] Validation script may reveal unexpected API behavior** -> If `categorie`/`type_competition_generique` sometimes return scalars despite dot-notation fields, we'll need a dual-mode converter. Mitigation: run validation script early (Phase 0.5) before committing to the approach.
+
+**[Trade-off] Extra `None` fields from subset merges** -> When `EngagementEquipe` (6 fields) replaces `IDEngagementEquipe` (3 fields), 3 fields will always be `None` in contexts that previously used the smaller model. Acceptable because `None` is the default for all optional fields.

--- a/openspec/changes/fix-conversion-mismatch-detection/proposal.md
+++ b/openspec/changes/fix-conversion-mismatch-detection/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The `discover_types.py` script identified **60 Tier 1** (type-level mismatches where `from_obj` receives scalars), **10 Tier 2** (enum value mismatches), **11 Tier 3** (value-level type mismatches), and **49 missing model fields**. Additionally, the model layer has accumulated significant technical debt: duplicate models representing the same JSON structures, inconsistent naming conventions (`*ID`, `*Class`, `*Ref` suffixes), name collisions across API-specific modules, and enum classes that shadow dataclass names.
+
+## What Changes
+
+- **BREAKING**: Rename all 30+ enum classes to `*Enum` suffix (e.g., `Sexe` → `SexeEnum`, `HitType` → `PratiquesHitTypeEnum`)
+- **BREAKING**: Deduplicate ~10 model classes by merging subsets into their supersets (e.g., `PurpleLogo` → `Logo`, `TeamEngagement` → `EngagementEquipe`, `OrganismeIDPere` → `Organisateur`)
+- **BREAKING**: Restructure `CompetitionID` + `CompetitionRef` into `CompetitionBase` + `Competition` + `CompetitionDetail` with shared base class
+- **BREAKING**: Rename models to remove `ID`/`Class`/`Ref` suffixes (e.g., `ExternalID` → `ExternalRencontre`, `SexeClass` → `SexeFacet`, `IDPoule` → `Poule`)
+- Fix ~20 FK properties using `from_obj` that receive scalar IDs → convert to `from_str`/`from_uuid`
+- Fix 5 value-type mismatches (e.g., `int | None` → `str | None` where API returns strings)
+- Add missing enum values to `TypeCompetition`, `PratiquesHitType`, `TournoisHitType`
+- Convert `DocumentFlyerType` enum to `str | None` (23+ MIME types, not enumerable)
+- Add 8 missing fields to `OrganismeFields`
+- Deduplicate cross-API enums (`SexeEnum` exists identically in both `models/` and `meilisearch_ffbb/models/`)
+- Delete orphaned file `meilisearch_ffbb/models/tournois_libelle.py`
+- Create validation script to confirm dot-notation FK fields (`categorie`, `type_competition_generique`) always return expanded dicts
+- Update all tests, scripts, and examples to reflect renames
+
+## Capabilities
+
+### New Capabilities
+- `model-naming-conventions`: Enforce consistent naming across the model layer — `*Enum` for enums, `*Facet` for facet-count dataclasses, PascalCase classes matching snake_case module names, no `ID`/`Class`/`Ref` suffixes
+- `model-deduplication`: Eliminate duplicate model classes by merging subsets into supersets, creating shared base classes where distinct variants exist
+- `converter-type-fixes`: Fix type mismatches in `from_dict` converters — FK scalars use `from_str`/`from_uuid`, value types match API reality
+- `fk-validation-script`: Validation script confirming dot-notation FK expansion behavior
+
+### Modified Capabilities
+
+## Impact
+
+- **Models** (`src/ffbb_api_client_v2/models/`): ~50 files renamed/modified/deleted. All enum and dataclass names change.
+- **MeiliSearch models** (`src/ffbb_api_client_v2/meilisearch_ffbb/models/`): ~10 files updated for import changes + 3 files deleted (duplicate enum, orphaned file)
+- **Directus models** (`src/ffbb_api_client_v2/directus_ffbb/models/`): ~15 files updated for import changes + field additions
+- **Public API**: All re-exports in `__init__.py` files change. This is a **major breaking change** for consumers importing model classes.
+- **Tests/Scripts/Examples**: All files referencing model names must be updated.
+- **SemVer**: Requires a **major version bump** due to breaking public API changes.

--- a/openspec/changes/fix-conversion-mismatch-detection/specs/converter-type-fixes/spec.md
+++ b/openspec/changes/fix-conversion-mismatch-detection/specs/converter-type-fixes/spec.md
@@ -1,0 +1,105 @@
+## ADDED Requirements
+
+### Requirement: FK properties receiving scalar IDs MUST use scalar converters
+When a Directus FK field returns a scalar value (string ID, integer, or UUID) instead of an expanded dict, the model property SHALL use the appropriate scalar converter (`from_str`, `from_int`, `from_uuid`) and type annotation.
+
+#### Scenario: Logo FK returns UUID
+- **WHEN** `EngagementEquipe.logo` receives a UUID string instead of a Logo dict
+- **THEN** the type SHALL be `UUID | None` and the converter SHALL be `from_uuid`
+- **AND** `to_dict` SHALL serialize with `str(self.logo)` or equivalent
+
+#### Scenario: FK returns string ID
+- **WHEN** `Organisateur.organisme_id_pere` receives a string ID
+- **THEN** the type SHALL be `str | None` and the converter SHALL be `from_str`
+
+#### Scenario: Competition FK scalar conversions
+- **WHEN** `CompetitionBase.logo` receives a UUID, `Competition.competition_origine` receives a string, `CompetitionDetail.saison` and `.organisateur` receive strings
+- **THEN** each SHALL use the matching scalar type and converter
+
+#### Scenario: CompetitionRencontre FK conversions
+- **WHEN** `CompetitionRencontre` FK fields (`id_organisme_equipe1`, `id_organisme_equipe2`, `gs_id`, `id_engagement_equipe1`, `id_engagement_equipe2`, `salle`) receive strings
+- **THEN** all SHALL be `str | None` with `from_str`
+
+#### Scenario: Salle FK conversions
+- **WHEN** `Salle.commune` and `Salle.cartographie` receive string IDs
+- **THEN** both SHALL be `str | None` with `from_str`
+
+#### Scenario: ExternalRencontre FK conversions
+- **WHEN** `ExternalRencontre` FK fields (`competition_id`, `id_organisme_equipe1`, `id_organisme_equipe2`, `salle`, `id_poule`) receive strings
+- **THEN** all SHALL be `str | None` with `from_str`
+
+#### Scenario: Live FK conversions
+- **WHEN** `Live.external_id`, `.team_engagement_home`, `.team_engagement_out` receive strings
+- **THEN** all SHALL be `str | None` with `from_str`
+
+#### Scenario: OrganismeEngagement FK conversions
+- **WHEN** `OrganismeEngagement.id_poule` and `.id_competition` receive strings
+- **THEN** both SHALL be `str | None` with `from_str`
+
+#### Scenario: PhaseEngagement FK conversion
+- **WHEN** `PhaseEngagement.id_organisme` receives a string
+- **THEN** it SHALL be `str | None` with `from_str`
+
+#### Scenario: TypeCompetitionGenerique FK conversion
+- **WHEN** `TypeCompetitionGenerique.logo` receives a UUID
+- **THEN** it SHALL be `UUID | None` with `from_uuid`
+
+### Requirement: Dot-notation expanded FK fields MUST keep model types
+When `competition_fields.py` uses dot-notation (e.g., `categorie.id`, `categorie.code`), the API always returns an expanded dict. These properties SHALL keep their model type with `from_obj`.
+
+#### Scenario: CompetitionBase.categorie stays Categorie
+- **WHEN** `competition_fields.py` specifies `categorie.id`, `categorie.code`, `categorie.libelle`, `categorie.ordre`
+- **THEN** `CompetitionBase.categorie` SHALL remain `Categorie | None` with `from_obj(Categorie.from_dict, ...)`
+
+#### Scenario: CompetitionBase.type_competition_generique stays model
+- **WHEN** `competition_fields.py` specifies `typeCompetitionGenerique.id`, `typeCompetitionGenerique.logo`
+- **THEN** `CompetitionBase.type_competition_generique` SHALL remain `TypeCompetitionGenerique | None`
+
+### Requirement: Value-type mismatches MUST be corrected
+When the API returns a different primitive type than the model expects, the model SHALL be updated to match.
+
+#### Scenario: Commune.commune_id int to str
+- **WHEN** `Commune.commune_id` uses `from_int` but the API returns a string
+- **THEN** it SHALL be changed to `str | None` with `from_str`
+
+#### Scenario: PratiquesHit.id int to str
+- **WHEN** `PratiquesHit.id` uses `from_int` but MeiliSearch returns a string
+- **THEN** it SHALL be changed to `str | None` with `from_str`
+
+#### Scenario: TerrainsHit.id int to str
+- **WHEN** `TerrainsHit.id` uses `from_int` but MeiliSearch returns a string
+- **THEN** it SHALL be changed to `str | None` with `from_str`
+
+#### Scenario: PouleRencontreItemModel.numero int to str
+- **WHEN** `PouleRencontreItemModel.numero` receives mixed `str | int` values
+- **THEN** it SHALL be `str | None` with `from_str` (single type policy)
+
+### Requirement: Missing enum values MUST be added
+When the API returns enum values not present in the Python enum definition, those values SHALL be added.
+
+#### Scenario: TypeCompetitionEnum missing values
+- **WHEN** the API returns `"DIV 3x3"` and `"PLAT"` which are not in `TypeCompetitionEnum`
+- **THEN** `DIV_3X3 = "DIV 3x3"` and `PLAT = "PLAT"` SHALL be added
+
+#### Scenario: PratiquesHitTypeEnum missing Point
+- **WHEN** the API returns `"Point"` which is not in `PratiquesHitTypeEnum`
+- **THEN** `POINT = "Point"` SHALL be added
+
+#### Scenario: TournoisHitTypeEnum missing Point
+- **WHEN** the API returns `"Point"` which is not in `TournoisHitTypeEnum`
+- **THEN** `POINT = "Point"` SHALL be added
+
+### Requirement: Unenumerable value sets MUST use str type
+When a field receives a large, open-ended set of values that cannot be reasonably enumerated, the property SHALL use `str | None` instead of an enum.
+
+#### Scenario: DocumentFlyerType to str
+- **WHEN** `DocumentFlyer.type` uses `DocumentFlyerType` enum (2 values) but receives 23+ MIME types
+- **THEN** the type SHALL be `str | None` with `from_str`
+- **AND** `document_flyer_type.py` SHALL be deleted
+
+### Requirement: Missing fields MUST be added to OrganismeFields
+Fields present in the API response but absent from `OrganismeFields.get_fields()` SHALL be added.
+
+#### Scenario: Add 8 missing organisme fields
+- **WHEN** the API returns `dateAffiliation`, `entreprise`, `handibasket`, `horsAssociation`, `logo_base64`, `omnisport`, `saison_en_cours`, `url_competition`
+- **THEN** these 8 fields SHALL be added to `OrganismeFields.get_fields()`

--- a/openspec/changes/fix-conversion-mismatch-detection/specs/fk-validation-script/spec.md
+++ b/openspec/changes/fix-conversion-mismatch-detection/specs/fk-validation-script/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: A validation script MUST confirm dot-notation FK expansion
+A script `scripts/validate_fk_expansion.py` SHALL verify that FK fields using dot-notation in `competition_fields.py` always return expanded dicts from the Directus API.
+
+#### Scenario: Validate categorie returns dict
+- **WHEN** the script requests a competition with fields including `categorie.id`, `categorie.code`, `categorie.libelle`, `categorie.ordre`
+- **THEN** the `categorie` field in the response SHALL be a `dict` (not a scalar)
+- **AND** the script SHALL report success
+
+#### Scenario: Validate type_competition_generique returns dict
+- **WHEN** the script requests a competition with fields including `typeCompetitionGenerique.id`, `typeCompetitionGenerique.logo`
+- **THEN** the `typeCompetitionGenerique` field in the response SHALL be a `dict` (not a scalar)
+- **AND** the script SHALL report success
+
+#### Scenario: Handle API unavailability
+- **WHEN** the Directus API is unreachable or authentication fails
+- **THEN** the script SHALL exit with a clear error message and non-zero exit code
+
+#### Scenario: Report unexpected scalar values
+- **WHEN** any checked FK field returns a scalar instead of a dict
+- **THEN** the script SHALL report a warning with the field name, expected type, and actual value
+- **AND** exit with non-zero exit code

--- a/openspec/changes/fix-conversion-mismatch-detection/specs/model-deduplication/spec.md
+++ b/openspec/changes/fix-conversion-mismatch-detection/specs/model-deduplication/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: Subset models MUST be merged into their supersets
+When a model's fields are a strict subset of another model mapping to the same JSON keys, the subset model SHALL be eliminated and replaced by the superset model everywhere.
+
+#### Scenario: Merge PurpleLogo into Logo
+- **WHEN** `PurpleLogo` (1 field: `id`) is a subset of `Logo` (2 fields: `id`, `gradient_color`)
+- **THEN** `PurpleLogo` SHALL be replaced by `Logo` in all usages
+- **AND** `purple_logo.py` SHALL be deleted
+
+#### Scenario: Merge CompetitionIDCategorie into Categorie
+- **WHEN** `CompetitionIDCategorie` (3 fields) is a subset of `Categorie` (6 fields)
+- **THEN** `CompetitionIDCategorie` SHALL be replaced by `Categorie`
+- **AND** `competition_id_categorie.py` SHALL be deleted
+
+#### Scenario: Merge single-field TypeCompetitionGenerique variants
+- **WHEN** `CompetitionIDTypeCompetitionGenerique` and `CompetitionOrigineTypeCompetitionGenerique` both have only `logo`
+- **AND** `TypeCompetitionGenerique` has `id` + `logo`
+- **THEN** both variants SHALL be replaced by `TypeCompetitionGenerique`
+- **AND** both variant files SHALL be deleted
+
+#### Scenario: Merge TeamEngagement into EngagementEquipe
+- **WHEN** `TeamEngagement` (4 fields) is a subset of `EngagementEquipe` (6 fields)
+- **THEN** `TeamEngagement` SHALL be replaced by `EngagementEquipe`
+- **AND** `team_engagement.py` SHALL be deleted
+
+#### Scenario: Merge IDEngagementEquipe into EngagementEquipe
+- **WHEN** `IDEngagementEquipe` (3 fields) is a subset of `EngagementEquipe` (6 fields)
+- **THEN** `IDEngagementEquipe` SHALL be replaced by `EngagementEquipe`
+- **AND** `id_engagement_equipe.py` SHALL be deleted
+
+#### Scenario: Merge OrganismeEquipe into IDOrganismeEquipe
+- **WHEN** `OrganismeEquipe` (1 field: `logo`) is a subset of `IDOrganismeEquipe` (6 fields)
+- **THEN** `OrganismeEquipe` SHALL be replaced by `IDOrganismeEquipe`
+- **AND** `organisme_equipe.py` SHALL be deleted
+- **AND** `IDOrganismeEquipe` SHALL be renamed to `OrganismeEquipe`
+
+#### Scenario: Merge OrganismeIDPere into Organisateur
+- **WHEN** `OrganismeIDPere` has 0 unique fields vs `Organisateur`
+- **AND** type differences (`id`: int vs str, `commune`: int vs str) are resolved to `str | None`
+- **THEN** `OrganismeIDPere` SHALL be replaced by `Organisateur`
+- **AND** `organisme_id_pere.py` SHALL be deleted
+
+### Requirement: Single-field wrapper models MUST be eliminated when the field becomes scalar
+When a model wraps a single FK field and that field is converted to a scalar type, the wrapper model SHALL be deleted.
+
+#### Scenario: Delete OrganismeId
+- **WHEN** `OrganismeId` has only `id: str | None`
+- **AND** `PhaseEngagement.id_organisme` is converted to `str | None`
+- **THEN** `OrganismeId` SHALL be deleted
+- **AND** `organisme_id.py` SHALL be deleted
+
+### Requirement: Competition models MUST use base class inheritance
+`CompetitionID` and `CompetitionRef` SHALL be restructured into a base class with two specialized subclasses.
+
+#### Scenario: Create CompetitionBase with shared fields
+- **WHEN** `CompetitionID` and `CompetitionRef` share 10 JSON keys
+- **THEN** a `CompetitionBase` dataclass SHALL be created with those 10 fields
+- **AND** `Competition` SHALL inherit from `CompetitionBase` with 5 additional fields (ex-`CompetitionID` unique fields)
+- **AND** `CompetitionDetail` SHALL inherit from `CompetitionBase` with 4 additional fields (ex-`CompetitionRef` unique fields)
+
+#### Scenario: Type alignment on shared competition_origine field
+- **WHEN** `competition_origine` is `CompetitionOrigine | None` in CompetitionID but `str | None` in CompetitionRef
+- **THEN** `CompetitionBase.competition_origine` SHALL use a single consistent type determined by the FK expansion context
+
+### Requirement: Facet-count models MUST be renamed
+Models containing facet distribution counts (e.g., `CompetitionIDTypeCompetition` with `championnat`, `coupe` fields) SHALL be renamed with the `Facet` suffix.
+
+#### Scenario: Rename CompetitionIDTypeCompetition
+- **WHEN** `CompetitionIDTypeCompetition` contains facet counts
+- **THEN** it SHALL be renamed to `CompetitionTypeFacet` in `competition_type_facet.py`
+
+### Requirement: Deleted model files MUST be removed from __init__.py
+When a model file is deleted, its import and `__all__` entry in the parent `__init__.py` SHALL be removed.
+
+#### Scenario: Clean up __init__.py after deletion
+- **WHEN** `purple_logo.py` is deleted
+- **THEN** `from .purple_logo import PurpleLogo` SHALL be removed from `__init__.py`
+- **AND** `"PurpleLogo"` SHALL be removed from `__all__`

--- a/openspec/changes/fix-conversion-mismatch-detection/specs/model-naming-conventions/spec.md
+++ b/openspec/changes/fix-conversion-mismatch-detection/specs/model-naming-conventions/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Enum classes MUST use the Enum suffix
+All Python `Enum` classes in the library SHALL be named with the `Enum` suffix (e.g., `SexeEnum`, `TypeCompetitionEnum`). The module file SHALL be named `snake_case` of the class name (e.g., `sexe_enum.py`).
+
+#### Scenario: Rename existing enum without Enum suffix
+- **WHEN** an enum class `Sexe` exists in `models/sexe.py`
+- **THEN** it SHALL be renamed to `SexeEnum` in `models/sexe_enum.py`
+- **AND** all imports across the codebase SHALL reference the new name and module
+
+#### Scenario: Resolve HitType name collision
+- **WHEN** two different enums share the name `HitType` in `pratiques_hit_type.py` and `tournois_hit_type.py`
+- **THEN** they SHALL be renamed to `PratiquesHitTypeEnum` and `TournoisHitTypeEnum` respectively
+
+#### Scenario: Resolve Libelle name collision
+- **WHEN** `Libelle` exists in both `models/tournoi_types_3x3_libelle_enum.py` and `meilisearch_ffbb/models/tournois_libelle.py`
+- **THEN** the models/ version SHALL be renamed `TournoiTypes3x3LibelleEnum`
+- **AND** the meilisearch orphan SHALL be deleted
+
+### Requirement: Facet-count dataclasses MUST use the Facet suffix
+Dataclasses that represent MeiliSearch facet distribution counts (fields mapping enum labels to `int` counts) SHALL use the `Facet` suffix instead of `Class`.
+
+#### Scenario: Rename SexeClass to SexeFacet
+- **WHEN** a facet-count dataclass `SexeClass` exists in `models/sexe_class.py`
+- **THEN** it SHALL be renamed to `SexeFacet` in `models/sexe_facet.py`
+
+#### Scenario: All Class-suffixed facet models renamed
+- **WHEN** facet models `NiveauClass`, `TypeClass`, `TournoiTypeClass`, `PratiquesTypeClass` exist
+- **THEN** they SHALL be renamed to `NiveauFacet`, `TypeFacet`, `TournoiTypeFacet`, `PratiquesTypeFacet`
+
+### Requirement: Models MUST NOT use ID, Class, or Ref suffixes
+Dataclass model names SHALL NOT contain `ID`, `Class`, or `Ref` as suffixes. Names SHALL describe the model's domain concept.
+
+#### Scenario: Rename ID-suffixed models
+- **WHEN** models `ExternalCompetitionID`, `ExternalID`, `IDOrganismeEquipe`, `IDPoule` exist
+- **THEN** they SHALL be renamed to `ExternalCompetition`, `ExternalRencontre`, `OrganismeEquipe`, `Poule`
+
+#### Scenario: Rename CompetitionRef
+- **WHEN** `CompetitionRef` exists
+- **THEN** it SHALL be renamed to `CompetitionDetail`
+
+### Requirement: Class names MUST match module names
+Every class `FooBar` SHALL live in a module named `foo_bar.py`. PascalCase for classes, snake_case for modules.
+
+#### Scenario: Verify class-module name consistency
+- **WHEN** a class is renamed
+- **THEN** the module file SHALL also be renamed to match `snake_case(ClassName)`
+- **AND** `__init__.py` exports SHALL be updated accordingly
+
+### Requirement: Cross-API enum deduplication
+When an identical enum exists in both `models/` and `meilisearch_ffbb/models/`, the global `models/` version SHALL be the single source of truth.
+
+#### Scenario: Deduplicate SexeEnum
+- **WHEN** `SexeEnum` exists in both `models/` (values: Feminin, Masculin, Mixte) and `meilisearch_ffbb/models/terrains_sexe_enum.py` (same values)
+- **THEN** the meilisearch file SHALL be deleted
+- **AND** `TournoisHit` SHALL import `SexeEnum` from the global `models/`
+- **AND** the Python attribute `MIXED` SHALL be standardized to `MIXTE`
+
+#### Scenario: Delete orphaned meilisearch enum
+- **WHEN** `meilisearch_ffbb/models/tournois_libelle.py` is imported nowhere
+- **THEN** it SHALL be deleted
+
+### Requirement: All consumers MUST be updated after renames
+Tests, scripts, and examples SHALL be updated to use new class and module names.
+
+#### Scenario: Update test imports
+- **WHEN** a model or enum is renamed
+- **THEN** all test files in `tests/` that import the old name SHALL be updated
+
+#### Scenario: Update script imports
+- **WHEN** a model or enum is renamed
+- **THEN** all script files in `scripts/` that reference the old name SHALL be updated
+
+#### Scenario: Update example imports
+- **WHEN** a model or enum is renamed
+- **THEN** all example files in `examples/` that reference the old name SHALL be updated

--- a/openspec/changes/fix-conversion-mismatch-detection/tasks.md
+++ b/openspec/changes/fix-conversion-mismatch-detection/tasks.md
@@ -1,0 +1,101 @@
+## 1. Phase 0 — Rename enums to *Enum suffix
+
+- [ ] 1.1 Rename 29 enum classes in `models/` (class name + file name): `Sexe`->`SexeEnum`, `Code`->`CodeEnum`, `Etat`->`EtatEnum`, `Jour`->`JourEnum`, `Label`->`LabelEnum`, `Niveau`->`NiveauEnum`, `Source`->`SourceEnum`, `Status`->`StatusEnum`, `Echelon`->`EchelonEnum`, `Pratique`->`PratiqueEnum`, `AgeGroup`->`AgeGroupEnum`, `Gender`->`GenderEnum`, `Objectif`->`ObjectifEnum`, `NiveauType`->`NiveauTypeEnum`, `CategorieType`->`CategorieTypeEnum`, `TypeLeague`->`TypeLeagueEnum`, `TypeCompetition`->`TypeCompetitionEnum`, `PhaseCode`->`PhaseCodeEnum`, `CodeFonction`->`CodeFonctionEnum`, `ContactRole`->`ContactRoleEnum`, `CoordonneesType`->`CoordonneesTypeEnum`, `OrganisateurType`->`OrganisateurTypeEnum`, `PublicationInternet`->`PublicationInternetEnum`, `CompetitionType`->`CompetitionTypeEnum`, `HitType`(pratiques)->`PratiquesHitTypeEnum`, `HitType`(tournois)->`TournoisHitTypeEnum`, `Libelle`->`TournoiTypes3x3LibelleEnum`, `CategorieChampionnat3X3Libelle`->`CategorieChampionnat3x3LibelleEnum`, `CompetitionOrigineTypeCompetition`->`CompetitionOrigineTypeCompetitionEnum`
+- [ ] 1.2 Rename 2 enum classes in `meilisearch_ffbb/models/`: `Name`->`TerrainsNameEnum`, `Storage`->`TerrainsStorageEnum`
+- [ ] 1.3 Update all `__init__.py` files with new imports and `__all__` entries
+- [ ] 1.4 Update all importing files across `models/`, `meilisearch_ffbb/`, `directus_ffbb/`, `tests/`, `scripts/`, `examples/`
+- [ ] 1.5 Deduplicate cross-API: delete `meilisearch_ffbb/models/terrains_sexe_enum.py`, point `TournoisHit` to global `SexeEnum`. Standardize `MIXED`->`MIXTE`
+- [ ] 1.6 Delete orphaned `meilisearch_ffbb/models/tournois_libelle.py`
+- [ ] 1.7 Verify: `python -m py_compile` on all changed files + `python -c "from ffbb_api_client_v2 import *"`
+- [ ] 1.8 Commit: `refactor(models): rename all enums to *Enum suffix, deduplicate cross-API enums`
+
+## 2. Phase 0.5 — FK expansion validation script
+
+- [ ] 2.1 Create `scripts/validate_fk_expansion.py`: verify `categorie` and `type_competition_generique` return dicts with dot-notation fields
+- [ ] 2.2 Run the script and document results
+- [ ] 2.3 Commit: `test(scripts): add FK expansion validation script`
+
+## 3. Phase 1 — Model deduplication and merging
+
+- [ ] 3.1 Replace `PurpleLogo` with `Logo` everywhere, delete `purple_logo.py`
+- [ ] 3.2 Replace `CompetitionIDCategorie` with `Categorie` in `CompetitionID`, delete `competition_id_categorie.py`
+- [ ] 3.3 Replace `CompetitionIDTypeCompetitionGenerique` and `CompetitionOrigineTypeCompetitionGenerique` with `TypeCompetitionGenerique`, delete both files
+- [ ] 3.4 Replace `TeamEngagement` with `EngagementEquipe`, delete `team_engagement.py`
+- [ ] 3.5 Replace `IDEngagementEquipe` with `EngagementEquipe`, delete `id_engagement_equipe.py`
+- [ ] 3.6 Replace `OrganismeEquipe` with `IDOrganismeEquipe`, delete `organisme_equipe.py`
+- [ ] 3.7 Replace `OrganismeIDPere` with `Organisateur` (after type alignment: `id`/`commune` to `str`), delete `organisme_id_pere.py`
+- [ ] 3.8 Delete `OrganismeId` (`organisme_id.py`), update `PhaseEngagement.id_organisme` to `str | None`
+- [ ] 3.9 Create `CompetitionBase` (10 shared fields), refactor `CompetitionID` into `Competition(CompetitionBase)` + 5 fields, refactor `CompetitionRef` into `CompetitionDetail(CompetitionBase)` + 4 fields. Delete `competition_id.py` and `competition_ref.py`
+- [ ] 3.10 Rename `CompetitionIDTypeCompetition` to `CompetitionTypeFacet` in `competition_type_facet.py`
+- [ ] 3.11 Update all `__init__.py` files, remove deleted imports
+- [ ] 3.12 Update all importing files across entire codebase
+- [ ] 3.13 Verify: compile check + import check
+- [ ] 3.14 Commit: `refactor(models): deduplicate models, create CompetitionBase hierarchy`
+
+## 4. Phase 2 — Enum value fixes
+
+- [ ] 4.1 Add `DIV_3X3 = "DIV 3x3"` and `PLAT = "PLAT"` to `TypeCompetitionEnum`
+- [ ] 4.2 Add `POINT = "Point"` to `PratiquesHitTypeEnum`
+- [ ] 4.3 Add `POINT = "Point"` to `TournoisHitTypeEnum`
+- [ ] 4.4 Convert `DocumentFlyer.type` from `DocumentFlyerType | None` to `str | None`, delete `document_flyer_type.py`
+- [ ] 4.5 Check `TournoiTypes3x3LibelleEnum` for missing values, add if needed
+- [ ] 4.6 Update `__init__.py` for deleted `document_flyer_type.py`
+- [ ] 4.7 Verify: compile check
+- [ ] 4.8 Commit: `fix(models): add missing enum values, convert DocumentFlyerType to str`
+
+## 5. Phase 3 — Model renaming
+
+- [ ] 5.1 Rename `ExternalCompetitionID` to `ExternalCompetition` (`external_competition.py`)
+- [ ] 5.2 Rename `ExternalID` to `ExternalRencontre` (`external_rencontre.py`)
+- [ ] 5.3 Rename `IDOrganismeEquipe` to `OrganismeEquipe` (`organisme_equipe.py`)
+- [ ] 5.4 Rename `IDPoule` to `Poule` (`poule.py`)
+- [ ] 5.5 Rename `SexeClass` to `SexeFacet` (`sexe_facet.py`), `NiveauClass` to `NiveauFacet` (`niveau_facet.py`), `TypeClass` to `TypeFacet` (`type_facet.py`), `TournoiTypeClass` to `TournoiTypeFacet` (`tournoi_type_facet.py`), `PratiquesTypeClass` to `PratiquesTypeFacet` (`pratiques_type_facet.py`)
+- [ ] 5.6 Update all `__init__.py` files with new imports
+- [ ] 5.7 Update all importing files across entire codebase (models, meilisearch, directus, tests, scripts, examples)
+- [ ] 5.8 Verify: compile check + import check
+- [ ] 5.9 Commit: `refactor(models): rename ID/Class-suffixed models to descriptive names`
+
+## 6. Phase 4 — FK from_obj to scalar converter fixes
+
+- [ ] 6.1 Fix Competition models: `CompetitionBase.logo`->`UUID`, `Competition.competition_origine`->`str`, `CompetitionDetail.saison`/`.organisateur`->`str`
+- [ ] 6.2 Fix `CompetitionRencontre`: `id_organisme_equipe1/2`, `gs_id`, `id_engagement_equipe1/2`, `salle` -> `str`
+- [ ] 6.3 Fix Engagement/Organisme: `EngagementEquipe.logo`->`UUID`, `OrganismeEquipe.logo`->`UUID`, `Organisateur.organisme_id_pere`->`str`, `OrganismeEngagement.id_poule`/`.id_competition`->`str`, `PhaseEngagement.id_organisme`->`str`, `TypeCompetitionGenerique.logo`->`UUID`
+- [ ] 6.4 Fix Salle: `commune`->`str`, `cartographie`->`str`
+- [ ] 6.5 Fix `ExternalRencontre`: `competition_id`, `id_organisme_equipe1/2`, `salle`, `id_poule` -> `str`
+- [ ] 6.6 Fix `Live`: `external_id`, `team_engagement_home`, `team_engagement_out` -> `str`
+- [ ] 6.7 Update `to_dict()` methods for all changed properties
+- [ ] 6.8 Verify: compile check
+- [ ] 6.9 Commit: `fix(models): convert FK from_obj to scalar converters for Directus FK fields`
+
+## 7. Phase 5 — Value type fixes
+
+- [ ] 7.1 Fix `Commune.commune_id`: `int | None` -> `str | None` with `from_str`
+- [ ] 7.2 Fix `PratiquesHit.id`: `int | None` -> `str | None` with `from_str`
+- [ ] 7.3 Fix `TerrainsHit.id`: `int | None` -> `str | None` with `from_str`
+- [ ] 7.4 Fix `PouleRencontreItemModel.numero`: `int | None` -> `str | None` with `from_str`
+- [ ] 7.5 Verify: compile check
+- [ ] 7.6 Commit: `fix(models): correct value type mismatches (int -> str)`
+
+## 8. Phase 6 — Missing OrganismeFields
+
+- [ ] 8.1 Add 8 fields to `OrganismeFields.get_fields()`: `dateAffiliation`, `entreprise`, `handibasket`, `horsAssociation`, `logo_base64`, `omnisport`, `saison_en_cours`, `url_competition`
+- [ ] 8.2 Verify: compile check
+- [ ] 8.3 Commit: `fix(models): add 8 missing fields to OrganismeFields`
+
+## 9. Phase 7 — Tests, scripts, examples update
+
+- [ ] 9.1 Update all test files in `tests/` for renamed classes/modules
+- [ ] 9.2 Update `scripts/discover_types.py` and other scripts for renamed classes
+- [ ] 9.3 Update all files in `examples/` for renamed classes
+- [ ] 9.4 Run `python -m pytest tests/` — all tests must pass
+- [ ] 9.5 Commit: `refactor(tests): update tests, scripts, examples for model renames`
+
+## 10. Phase 8 — Final cleanup and verification
+
+- [ ] 10.1 Verify no orphaned model files remain (grep for old class names)
+- [ ] 10.2 Verify all `__init__.py` exports are consistent
+- [ ] 10.3 Verify class name <-> module name consistency (PascalCase <-> snake_case)
+- [ ] 10.4 Run full verification: `python -m py_compile`, `python -m pytest tests/`, `python -c "from ffbb_api_client_v2 import *"`
+- [ ] 10.5 Run `scripts/discover_types.py` and verify Tier 1/2/3 counts decreased
+- [ ] 10.6 Run `scripts/validate_fk_expansion.py` and confirm results
+- [ ] 10.7 Commit any remaining fixes: `chore: final cleanup after model restructuring`

--- a/scripts/validate-local.sh
+++ b/scripts/validate-local.sh
@@ -103,10 +103,12 @@ if [ -d .github/workflows ]; then
       fi
     fi
     if [ -f .github/workflows/ci.yml ]; then
+      # Only run the prepare job locally; test/publish jobs require GitHub
+      # artifact services. Local tests are already covered by tox above.
       if [ -f .secrets.act ]; then
-        act pull_request -W .github/workflows/ci.yml --secret-file .secrets.act
+        act pull_request -W .github/workflows/ci.yml --job prepare --secret-file .secrets.act
       else
-        act pull_request -W .github/workflows/ci.yml
+        act pull_request -W .github/workflows/ci.yml --job prepare
       fi
     fi
   fi

--- a/src/ffbb_api_client_v2/directus_ffbb/models/get_engagements_response.py
+++ b/src/ffbb_api_client_v2/directus_ffbb/models/get_engagements_response.py
@@ -26,7 +26,7 @@ class GetEngagementsResponse:
     nomEquipe: str | None = None
     nomUsuel: str | None = None
     nomOfficiel: str | None = None
-    numeroEquipe: int | None = None
+    numeroEquipe: str | None = None
     codeAbrege: str | None = None
     clubPro: bool | None = None
     position: int | None = None
@@ -89,7 +89,7 @@ class GetEngagementsResponse:
             nomEquipe=from_str(data, "nomEquipe"),
             nomUsuel=from_str(data, "nomUsuel"),
             nomOfficiel=from_str(data, "nomOfficiel"),
-            numeroEquipe=from_int(data, "numeroEquipe"),
+            numeroEquipe=from_str(data, "numeroEquipe"),
             codeAbrege=from_str(data, "codeAbrege"),
             clubPro=from_bool(data, "clubPro"),
             position=from_int(data, "position"),

--- a/src/ffbb_api_client_v2/directus_ffbb/models/get_engagements_response.py
+++ b/src/ffbb_api_client_v2/directus_ffbb/models/get_engagements_response.py
@@ -43,7 +43,7 @@ class GetEngagementsResponse:
     # FK-only: Directus file UUIDs
     logo: UUID | None = None
     logo_genius: UUID | None = None
-    photo: UUID | None = None
+    photo: str | None = None
     # FK-only: lists
     rencontres_domiciles: list[int | Any] = field(default_factory=list)
     rencontres_exterieur: list[int | Any] = field(default_factory=list)
@@ -104,7 +104,7 @@ class GetEngagementsResponse:
             entraineurAdjoint=from_int(data, "entraineurAdjoint"),
             logo=from_uuid(data, "logo"),
             logo_genius=from_uuid(data, "logo_genius"),
-            photo=from_uuid(data, "photo"),
+            photo=from_str(data, "photo"),
             rencontres_domiciles=(
                 domiciles_raw if isinstance(domiciles_raw, list) else []
             ),

--- a/src/ffbb_api_client_v2/directus_ffbb/models/get_pratiques_response.py
+++ b/src/ffbb_api_client_v2/directus_ffbb/models/get_pratiques_response.py
@@ -8,7 +8,6 @@ from ...models.cartographie import Cartographie
 from ...utils.converter_utils import (
     from_datetime,
     from_float,
-    from_int,
     from_obj,
     from_str,
     from_timestamp,
@@ -51,8 +50,8 @@ class GetPratiquesResponse:
     cartographie: Cartographie | None = None
     latitude: float | None = None
     longitude: float | None = None
-    nombre_personnes: int | None = None
-    nombre_seances: int | None = None
+    nombre_personnes: str | None = None
+    nombre_seances: str | None = None
     public: str | None = None
     objectif: str | None = None
     site_web: str | None = None
@@ -106,8 +105,8 @@ class GetPratiquesResponse:
             cartographie=from_obj(Cartographie.from_dict, data, "cartographie"),
             latitude=from_float(data, "latitude"),
             longitude=from_float(data, "longitude"),
-            nombre_personnes=from_int(data, "nombre_personnes"),
-            nombre_seances=from_int(data, "nombre_seances"),
+            nombre_personnes=from_str(data, "nombre_personnes"),
+            nombre_seances=from_str(data, "nombre_seances"),
             public=data.get("public"),  # Keep as raw
             objectif=data.get("objectif"),  # Keep as raw
             site_web=data.get("site_web"),  # Keep as raw

--- a/src/ffbb_api_client_v2/directus_ffbb/models/get_rencontres_response.py
+++ b/src/ffbb_api_client_v2/directus_ffbb/models/get_rencontres_response.py
@@ -33,8 +33,8 @@ class GetRencontresResponse:
     forfaitEquipe2: bool | None = None
     defautEquipe1: bool | None = None
     defautEquipe2: bool | None = None
-    penaliteEquipe1: int | None = None
-    penaliteEquipe2: int | None = None
+    penaliteEquipe1: bool | None = None
+    penaliteEquipe2: bool | None = None
     handicap1: int | None = None
     handicap2: int | None = None
     remise: bool | None = None
@@ -90,8 +90,8 @@ class GetRencontresResponse:
             forfaitEquipe2=from_bool(data, "forfaitEquipe2"),
             defautEquipe1=from_bool(data, "defautEquipe1"),
             defautEquipe2=from_bool(data, "defautEquipe2"),
-            penaliteEquipe1=from_int(data, "penaliteEquipe1"),
-            penaliteEquipe2=from_int(data, "penaliteEquipe2"),
+            penaliteEquipe1=from_bool(data, "penaliteEquipe1"),
+            penaliteEquipe2=from_bool(data, "penaliteEquipe2"),
             handicap1=from_int(data, "handicap1"),
             handicap2=from_int(data, "handicap2"),
             remise=from_bool(data, "remise"),

--- a/src/ffbb_api_client_v2/directus_ffbb/models/get_tournois_response.py
+++ b/src/ffbb_api_client_v2/directus_ffbb/models/get_tournois_response.py
@@ -38,7 +38,7 @@ class GetTournoisResponse:
     commune: int | None = None
     cartographie: Cartographie | None = None
     tournoiTypes3x3: list[int] = field(default_factory=list)
-    document_flyer: DocumentFlyer | None = None
+    document_flyer: DocumentFlyer | str | None = None
     categorieChampionnat3x3Id: str | None = None
     categorieChampionnat3x3Libelle: str | None = None
     date_created: datetime | None = None
@@ -79,7 +79,11 @@ class GetTournoisResponse:
             tournoiTypes3x3=[
                 int(x) for x in (data.get("tournoiTypes3x3") or []) if x is not None
             ],
-            document_flyer=from_obj(DocumentFlyer.from_dict, data, "document_flyer"),
+            document_flyer=(
+                DocumentFlyer.from_dict(data["document_flyer"])
+                if isinstance(data.get("document_flyer"), dict)
+                else from_str(data, "document_flyer")
+            ),
             categorieChampionnat3x3Id=data.get(
                 "categorieChampionnat3x3Id"
             ),  # Keep as raw

--- a/src/ffbb_api_client_v2/meilisearch_ffbb/models/engagements_hit.py
+++ b/src/ffbb_api_client_v2/meilisearch_ffbb/models/engagements_hit.py
@@ -11,7 +11,6 @@ from ...models.geo import Geo
 from ...models.id_poule import IDPoule
 from ...utils.converter_utils import (
     from_bool,
-    from_int,
     from_obj,
     from_str,
 )
@@ -43,7 +42,7 @@ class EngagementsHit(Hit):
     nom_officiel: str | None = None
     nom_organisme: str | None = None
     nom_usuel: str | None = None
-    numero_equipe: int | None = None
+    numero_equipe: str | None = None
     thumbnail: str | None = None
     gradient_color: str | None = None
     geo: Geo | None = None
@@ -87,7 +86,7 @@ class EngagementsHit(Hit):
         nom_officiel = from_str(obj, "nomOfficiel")
         nom_organisme = from_str(obj, "nomOrganisme")
         nom_usuel = from_str(obj, "nomUsuel")
-        numero_equipe = from_int(obj, "numeroEquipe")
+        numero_equipe = from_str(obj, "numeroEquipe")
         thumbnail = from_str(obj, "thumbnail")
         gradient_color = from_str(obj, "gradient_color")
         geo = from_obj(Geo.from_dict, obj, "_geo")

--- a/src/ffbb_api_client_v2/models/code.py
+++ b/src/ffbb_api_client_v2/models/code.py
@@ -4,4 +4,5 @@ from enum import Enum
 class Code(Enum):
     BIT = "BIT"
     BT = "BT"
+    EBTP = "EBTP"
     SS = "SS"

--- a/src/ffbb_api_client_v2/models/label.py
+++ b/src/ffbb_api_client_v2/models/label.py
@@ -15,3 +15,4 @@ class Label(Enum):
     DÉCOUVERTE_MICRO_BASKET = "Découverte Micro Basket"
     EMPTY = ""
     MICRO_BASKET = "Micro Basket"
+    MICRO_BASKET_DÉCOUVERTE = "Micro Basket / Découverte"

--- a/src/ffbb_api_client_v2/models/ranking_engagement.py
+++ b/src/ffbb_api_client_v2/models/ranking_engagement.py
@@ -14,7 +14,7 @@ class RankingEngagement:
     nom_usuel: str | None = None
     code_abrege: str | None = None
     numero_equ: int | None = None
-    numero_equipe: int | None = None
+    numero_equipe: str | None = None
     logo_id: str | None = None
     logo_gradient: str | None = None
 
@@ -37,7 +37,7 @@ class RankingEngagement:
             nom_usuel=from_str(data, "nomUsuel"),
             code_abrege=from_str(data, "codeAbrege"),
             numero_equ=from_int(data, "numeroEqu"),
-            numero_equipe=from_int(data, "numeroEquipe"),
+            numero_equipe=from_str(data, "numeroEquipe"),
             logo_id=logo_id,
             logo_gradient=logo_gradient,
         )

--- a/src/ffbb_api_client_v2/models/team_ranking.py
+++ b/src/ffbb_api_client_v2/models/team_ranking.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from ..utils.converter_utils import from_bool, from_float, from_int, from_obj, from_str
+from ..utils.converter_utils import from_bool, from_float, from_int, from_str
 from .ranking_engagement import RankingEngagement
 
 
@@ -12,7 +12,7 @@ class TeamRanking:
 
     # Required fields first
     id: str
-    id_engagement: RankingEngagement | None
+    id_engagement: RankingEngagement | str | None
     position: int
     points: int
     match_joues: int
@@ -50,7 +50,13 @@ class TeamRanking:
         if not isinstance(data, dict):
             return None
 
-        id_engagement = from_obj(RankingEngagement.from_dict, data, "idEngagement")
+        id_engagement_raw = data.get("idEngagement")
+        if isinstance(id_engagement_raw, dict):
+            id_engagement = RankingEngagement.from_dict(id_engagement_raw)
+        elif isinstance(id_engagement_raw, (str, int)):
+            id_engagement = str(id_engagement_raw)
+        else:
+            id_engagement = None
 
         # Handle organisme data
         organisme_data = data.get("organisme", {})

--- a/src/ffbb_api_client_v2/models/type_competition.py
+++ b/src/ffbb_api_client_v2/models/type_competition.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 
 
@@ -5,4 +7,13 @@ class TypeCompetition(Enum):
     CHAMPIONNAT = "Championnat"
     CHAMPIONNAT_3_X3 = "Championnat 3x3"
     COUPE = "Coupe"
+    DIV = "DIV"
     PLATEAU = "Plateau"
+
+    @classmethod
+    def _missing_(cls, value: object) -> TypeCompetition | None:
+        if isinstance(value, str):
+            for member in cls:
+                if member.value.upper() == value.upper():
+                    return member
+        return None

--- a/tests/integration/test_506_raw_json_model_conversion.py
+++ b/tests/integration/test_506_raw_json_model_conversion.py
@@ -826,7 +826,7 @@ class Test021FromDictEdgeCases(unittest.TestCase):
         self.assertEqual(eng.nom_usuel, "Paris BC")
         self.assertEqual(eng.code_abrege, "PBC")
         self.assertEqual(eng.numero_equ, 1)
-        self.assertEqual(eng.numero_equipe, 1)
+        self.assertEqual(eng.numero_equipe, "001")
         self.assertEqual(eng.logo_id, "logo-123")
         self.assertEqual(eng.logo_gradient, "#FF0000")
 

--- a/tests/unit/models/test_000_get_engagements_response.py
+++ b/tests/unit/models/test_000_get_engagements_response.py
@@ -321,7 +321,7 @@ class TestGetEngagementsResponse(unittest.TestCase):
     def test_040_field_photo(self) -> None:
         result = GetEngagementsResponse.from_dict(SAMPLE_DATA)
         assert result is not None
-        self.assertIsInstance(result.photo, UUID)
+        self.assertIsInstance(result.photo, str)
 
     def test_041_field_id_organisme_ctc(self) -> None:
         result = GetEngagementsResponse.from_dict(SAMPLE_DATA)

--- a/tests/unit/models/test_000_get_engagements_response.py
+++ b/tests/unit/models/test_000_get_engagements_response.py
@@ -20,7 +20,7 @@ SAMPLE_DATA: dict[str, Any] = {
     "nomEquipe": "Equipe 1",
     "nomUsuel": "CA MANTES",
     "nomOfficiel": "CA MANTES LA VILLE BASKET",
-    "numeroEquipe": "1",  # string in API, converted to int by from_int
+    "numeroEquipe": "1",
     "codeAbrege": "MAN",
     "clubPro": False,
     "position": 3,
@@ -138,7 +138,7 @@ class TestGetEngagementsResponse(unittest.TestCase):
     def test_012_field_numero_equipe(self) -> None:
         result = GetEngagementsResponse.from_dict(SAMPLE_DATA)
         assert result is not None
-        self.assertEqual(result.numeroEquipe, 1)
+        self.assertEqual(result.numeroEquipe, "1")
 
     def test_013_field_code_abrege(self) -> None:
         result = GetEngagementsResponse.from_dict(SAMPLE_DATA)

--- a/tests/unit/models/test_ranking_engagement.py
+++ b/tests/unit/models/test_ranking_engagement.py
@@ -52,7 +52,7 @@ class TestRankingEngagement(unittest.TestCase):
         self.assertEqual(result.nom_usuel, "Paris BC")
         self.assertEqual(result.code_abrege, "PBC")
         self.assertEqual(result.numero_equ, 1)
-        self.assertEqual(result.numero_equipe, 1)
+        self.assertEqual(result.numero_equipe, "001")
         self.assertEqual(result.logo_id, "logo-123")
         self.assertEqual(result.logo_gradient, "#FF0000")
 


### PR DESCRIPTION
## Summary
- Add OpenSpec change proposal for fixing conversion type mismatches (model deduplication, enum naming, FK validation, converter fixes)
- Fix test assertion for `numero_equipe` field (str type after da53e26)
- Fix local `act` CI replay: skip `upload-artifact@v4` when `ACT` env is set, limit replay to `prepare` job

## Test plan
- [x] All 1752 tests pass locally
- [x] `act pull_request --job prepare` succeeds
- [x] Pre-push hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)